### PR TITLE
made delete feature in tables optional

### DIFF
--- a/src/framework/processing/py/port/api/props.py
+++ b/src/framework/processing/py/port/api/props.py
@@ -100,6 +100,7 @@ class PropsUIPromptConsentFormTable:
     description: Optional[Translatable] = None
     visualizations: Optional[list] = None
     folded: Optional[bool] = False
+    delete_option: Optional[bool] = True
 
     def toDict(self):
         dict = {}
@@ -110,6 +111,7 @@ class PropsUIPromptConsentFormTable:
         dict["description"] = self.description.toDict() if self.description else None
         dict["visualizations"] = self.visualizations if self.visualizations else None
         dict["folded"] = self.folded
+        dict["delete_option"] = self.delete_option
         return dict
 
 

--- a/src/framework/processing/py/port/script.py
+++ b/src/framework/processing/py/port/script.py
@@ -177,7 +177,7 @@ def generate_consent_prompt(*args: pd.DataFrame) -> props.PropsUIPromptConsentFo
             "textColumn": "File name",
             "tokenize": True,
         }
-        tables.append(props.PropsUIPromptConsentFormTable(f"zip_contents_{index}", table_title, df, visualizations=[wordcloud]))
+        tables.append(props.PropsUIPromptConsentFormTable(f"zip_contents_{index}", table_title, df, visualizations=[wordcloud], delete_option=True))
 
     return props.PropsUIPromptConsentForm(
        tables,

--- a/src/framework/types/elements.ts
+++ b/src/framework/types/elements.ts
@@ -391,6 +391,7 @@ export interface TableContext {
   deletedRows: string[][]
   visualizations?: any[]
   folded: boolean
+  deleteOption: boolean
 }
 
 export type TableWithContext = TableContext & PropsUITable

--- a/src/framework/types/prompts.ts
+++ b/src/framework/types/prompts.ts
@@ -87,6 +87,7 @@ export interface PropsUIPromptConsentFormTable {
   data_frame: any
   visualizations: any
   folded: boolean
+  delete_option: boolean
 }
 export function isPropsUIPromptConsentFormTable(arg: any): arg is PropsUIPromptConsentFormTable {
   return isInstanceOf<PropsUIPromptConsentFormTable>(arg, "PropsUIPromptConsentFormTable", [

--- a/src/framework/visualisation/react/ui/elements/table.tsx
+++ b/src/framework/visualisation/react/ui/elements/table.tsx
@@ -119,14 +119,18 @@ export const Table = ({
     }
     return (
       <tr key={item.id} className='border-b-2 border-grey4 border-solid'>
-        <td key='select'>
-          <CheckBox
-            id={item.id}
-            size='w-6 h-6'
-            selected={selected.has(item.id)}
-            onSelect={() => toggleSelected(item.id)}
-          />
-        </td>
+        {table.deleteOption &&
+          (
+            <td key='select'>
+              <CheckBox
+                id={item.id}
+                size='w-6 h-6'
+                selected={selected.has(item.id)}
+                onSelect={() => toggleSelected(item.id)}
+              />
+            </td>
+          )
+        }
 
         {item.cells.map((cell, j) => (
           <td key={j}>
@@ -165,14 +169,18 @@ export const Table = ({
             <table className='table-fixed min-w-full '>
               <thead className=''>
                 <tr className='border-b-2 border-grey4 border-solid'>
-                  <td className='w-8'>
-                    <CheckBox
-                      id='selectAll'
-                      size='w-6 h-6'
-                      selected={table.body.rows.length > 0 && selected.size === table.body.rows.length}
-                      onSelect={toggleSelectAll}
-                    />
-                  </td>
+                  {table.deleteOption &&
+                    (
+                      <td className='w-8'>
+                        <CheckBox
+                          id='selectAll'
+                          size='w-6 h-6'
+                          selected={table.body.rows.length > 0 && selected.size === table.body.rows.length}
+                          onSelect={toggleSelectAll}
+                        />
+                      </td>
+                    )
+                  }
                   {columnNames.map(renderHeaderCell)}
                 </tr>
               </thead>
@@ -188,6 +196,7 @@ export const Table = ({
                     label={`${text.delete} ${selected.size > 0 ? selectedLabel : ''}`}
                     color='text-delete'
                     disabled={selected.size === 0}
+                    hidden={!table.deleteOption}
                     onClick={() => handleDelete?.(Array.from(selected))}
                   />
                   )

--- a/src/framework/visualisation/react/ui/prompts/consent_form.tsx
+++ b/src/framework/visualisation/react/ui/prompts/consent_form.tsx
@@ -112,6 +112,7 @@ export const ConsentForm = (props: Props): JSX.Element => {
       deletedRows: [],
       visualizations: tableData.visualizations,
       folded: tableData.folded || false,
+      deleteOption: tableData.delete_option,
     }
   }
 


### PR DESCRIPTION
When creating tables, one can now use an (optional) argument *delete_option* to indicate whether records/rows of the table should be deletable (default is True). If False, check-boxes disappear (including the select-all box) and the icon-button for removal becomes hidden.

This closes #13.