### PR TITLE
Sphinx docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - sphinx-docs-workflow
   pull_request:
     branches:
       - master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Build Documentation and Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  docs-build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme myst_parser
+      - name: Sphinx build
+        run: |
+          sphinx-build doc _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_branch: gh-pages-docs
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 
 # testing
 /coverage
+/_build
+/.venv
 
 # production
 /build

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,22 +1,27 @@
 # API reference
 
-## Helpers
+## Props
 
-### Extraction helpers
+```{eval-rst}
+.. automodule:: port.api.props
+   :members:
+```
+
+## Extraction helpers
 
 ```{eval-rst}
 .. automodule:: port.helpers.extraction_helpers
    :members:
 ```
 
-### Port helpers
+## Port helpers
 
 ```{eval-rst}
 .. automodule:: port.helpers.port_helpers
    :members:
 ```
 
-### Validation
+## Validation
 
 ```{eval-rst}
 .. automodule:: port.helpers.validate

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,33 @@
+# API reference
+
+## Helpers
+
+### Extraction helpers
+
+```{eval-rst}
+.. automodule:: port.helpers.extraction_helpers
+   :members:
+```
+
+### Port helpers
+
+```{eval-rst}
+.. automodule:: port.helpers.port_helpers
+   :members:
+```
+
+### Validation
+
+```{eval-rst}
+.. automodule:: port.helpers.validate
+   :members:
+```
+
+## Platforms
+
+### ChatGPT
+
+```{eval-rst}
+.. automodule:: port.platforms.chatgpt
+   :members:
+```

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,5 +32,5 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
+html_theme = 'haiku'
 html_static_path = ['_static']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,36 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../src/framework/processing/py/'))
+
+# Ignore external dependencies
+autodoc_mock_imports = ['pandas', 'numpy']
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Port'
+copyright = '2024, Boeschoten et al.'
+author = 'Boeschoten et al.'
+release = '1.0.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['myst_parser', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.napoleon']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,8 @@
+Port documentation
+==================
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Contents:
+
+   api.md

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
Added sphinx documentation with basic design.

docs are auto-built on specified modules in */src/framework/processing/py/*
 - props
 - extraction helpers
 - port helpers
 - validation
 - platforms

gh actions workflow builds docs and deploys them to gh-pages-docs branch

closes #20