### PR TITLE
PR 5: v2.0.0 documentation: CHANGELOG, migration guide, and tutorial rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,60 @@
 # Changelog
 
-## Types of Changes and How to Note Them
+This project follows [semantic versioning](https://semver.org/) starting from v2.0.0.
+Earlier releases used sequential numbering (#1-#5) matching the upstream
+[eyra/feldspar](https://github.com/eyra/feldspar) convention.
 
-* Added - For any new features that have been added since the last version was released
-* Changed - To note any changes to the software's existing functionality
-* Deprecated - To note any features that were once stable but are no longer and have thus been removed
-* Fixed - Any bugs or errors that have been fixed should be so noted
-* Removed - This notes any features that have been deleted and removed from the software
-* Security - This acts as an invitation to users who want to upgrade and avoid any software vulnerabilities
+## v2.0.0 — 2026-03-23
 
-## \#7 2026-03-05
+Incorporates upstream eyra/feldspar #6 (2026-02-25) and #7 (2026-03-05), plus
+d3i extraction consolidation, platform updates, and bridge alignment.
 
-* Added status text during data submission to inform users to keep the window open
-* Added CommandSystemLog for forwarding logs from JavaScript and Python to the hosting application
-* Changed Tailwind CSS to v4
-* Changed CI workflows: added dependency update testing, feature branch releases
-* Removed unused _build_release.yml workflow
+### Breaking
 
-## \#6 2026-02-25
+* File delivery uses PayloadFile (FileReaderSync) instead of WORKERFS/PayloadString
+* CommandSystemLog forwarding from Python and JS to host platform
+* Donation keys changed from `{session_id}` to `{session_id}-{platform_name}`
+* script.py rewritten as FlowBuilder orchestrator — forks using the old script.py pattern must migrate
+* ScriptWrapper catches all Python exceptions as PII safety boundary (AD0009)
 
-* Added maximum data frame sizes to both the API and UI
-* Added GitHub Actions release workflow with automated testing
-* Added unit tests for dataframe truncation (Python and JavaScript)
-* Added Lithuanian (LT) and Romanian (RO) translations
-* Added Git LFS for test fixtures
-* Fixed case-insensitive search in consent table
-* Removed redundant Playwright workflow (consolidated into release workflow)
+### Added
+
+* FlowBuilder: standard template for per-platform extraction flows (extraction/AD0001)
+* ZipArchiveReader: deterministic archive member resolution with cached inventory (extraction/AD0006)
+* ExtractionResult dataclass with Counter[str] error counting
+* Chrome platform extraction
+* Upload validation — file type and size checks before extraction (extraction/AD0003)
+* PII-safe logging boundaries — explicit CommandSystemLog yields for host-visible milestones, local loggers for diagnostics (AD0011)
+* Per-platform release builds via VITE_PLATFORM env var (fork-governance/AD0005)
+* Verification commands: `pnpm test`, `pnpm typecheck:py`, `pnpm verify:py`, `pnpm doctor`
+* 74 Python unit tests
+* Dependency update CI workflow
+* DISCLAIMER.md (EUPL)
+* 20+ architectural decision records in `docs/decisions/`
+
+### Changed
+
+* All 9 existing platforms migrated to FlowBuilder + ZipArchiveReader + bilingual headers
+* Font: Finador replaced with Nunito (open-source)
+* Tailwind CSS v3 → v4
+* Dataframe truncation limits (Python + TypeScript) to prevent UI overload
+* Status text shown during data submission
+* Error page shows user-friendly message instead of stacktrace
+* Async donation responses via PayloadResponse (backward-compatible with PayloadVoid)
+* Case-insensitive search in consent table (from eyra #6)
+* Lithuanian and Romanian translations (from eyra #6)
+
+### Removed
+
+* `d3i_example_script.py` — superseded by FlowBuilder pattern
+* `donation_flows/` extraction system — consolidated into FlowBuilder (AD0006)
+* `script_custom_ui.py` — eyra demo script, not used by d3i platforms
+* `d3i_py_worker.js` — dead code, all worker traffic through `py_worker.js`
+* Dead CI workflows: `_build_release.yml` (Earthly), `playwright.yml`, `release.yml`
+
+### Migration
+
+See [MIGRATION.md](MIGRATION.md) for a guide to updating downstream forks.
 
 ## \#5 2025-09-10
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,204 @@
+# Migrating to v2.0.0
+
+This guide is for researchers with downstream forks of d3i-infra/data-donation-task
+who need to update their code for the v2.0.0 release.
+
+## What changed and why
+
+The extraction architecture was consolidated around **FlowBuilder** — a template
+class that handles the common donation flow (file prompt → validation → extraction →
+consent → donation) so that each platform only needs to implement two methods:
+`validate_file()` and `extract_data()`.
+
+This replaces the previous pattern where each platform's `process()` function
+contained the full flow logic, including UI construction, retry handling, and
+donation. The old `d3i_example_script.py` and `donation_flows/` system have been
+removed.
+
+For detailed rationale, see:
+- `docs/decisions/python-architecture/AD0006` — consolidation decision
+- `docs/decisions/extraction/AD0001` — FlowBuilder template pattern
+- `docs/decisions/extraction/AD0006` — ZipArchiveReader and error handling
+
+## If you use the default platforms as-is
+
+Minimal changes needed:
+
+1. **Update your fork** — merge or rebase onto v2.0.0
+2. **Check `DDP_CATEGORIES`** — each platform defines which file formats it
+   supports. If your participants use a DDP format not listed, add a new
+   `DDPCategory` entry
+3. **Verify** — run `pnpm doctor` to check your environment, `pnpm test` to
+   run the test suite, `pnpm start` to test locally
+
+## If you have a custom script.py
+
+The main migration. Here's what changed:
+
+### Before (v1.x pattern)
+
+```python
+# script.py or d3i_example_script.py
+def process(sessionId):
+    # Manually build file prompt
+    promptFile = prompt_file("application/zip, text/plain")
+    fileResult = yield render_page([promptFile])
+
+    if fileResult.__type__ == "PayloadString":
+        zipfile_ref = get_zipfile(fileResult.value)
+        files = get_files(zipfile_ref)
+        extraction_result = []
+        for filename in files:
+            extraction_result.append(extract_file(zipfile_ref, filename))
+
+        # Manually build consent UI
+        for prompt in prompt_consent(extraction_result):
+            result = yield prompt
+            if result.__type__ == "PayloadJSON":
+                yield donate(f"{sessionId}-key", result.value)
+```
+
+### After (v2.0.0 FlowBuilder pattern)
+
+```python
+# platforms/my_platform.py
+from port.helpers.flow_builder import FlowBuilder
+from port.helpers.validate import DDPCategory, DDPFiletype, Language
+import port.helpers.validate as validate
+
+DDP_CATEGORIES = [
+    DDPCategory(
+        id="json_en",
+        ddp_filetype=DDPFiletype.JSON,
+        language=Language.EN,
+        known_files=["data.json", "profile.json"]
+    )
+]
+
+class MyPlatformFlow(FlowBuilder):
+    def __init__(self, session_id: str):
+        super().__init__(session_id, "MyPlatform")
+
+    def validate_file(self, file):
+        return validate.validate_zip(DDP_CATEGORIES, file)
+
+    def extract_data(self, file_value, validation):
+        return extraction(file_value, validation)
+
+def process(session_id):
+    flow = MyPlatformFlow(session_id)
+    return flow.start_flow()
+```
+
+```python
+# script.py — thin orchestrator
+from importlib import import_module
+import port.helpers.port_helpers as ph
+
+PLATFORM_REGISTRY = [
+    ("MyPlatform", "port.platforms.my_platform", "MyPlatformFlow"),
+]
+
+def process(session_id: str, platform: str | None = None):
+    entries = PLATFORM_REGISTRY
+    if platform:
+        entries = [(n, m, c) for n, m, c in entries if n.lower() == platform.lower()]
+
+    for name, module_path, class_name in entries:
+        mod = import_module(module_path)
+        FlowClass = getattr(mod, class_name)
+        flow = FlowClass(session_id)
+        yield from flow.start_flow()
+```
+
+FlowBuilder handles: file prompting, retry on invalid files, upload safety
+checks, consent UI, donation, and no-data acknowledgment. You only write the
+validation and extraction logic.
+
+See `packages/python/port/platforms/linkedin.py` for a complete working example.
+
+## If you have custom extraction functions
+
+Extraction functions should return an `ExtractionResult`:
+
+```python
+from port.api.d3i_props import ExtractionResult
+from collections import Counter
+
+def extraction(zip_path: str, validation) -> ExtractionResult:
+    errors = Counter()
+    reader = ZipArchiveReader(zip_path, validation.archive_members, errors)
+
+    tables = [
+        # your consent form tables here
+    ]
+    return ExtractionResult(tables=tables, errors=errors)
+```
+
+`ZipArchiveReader` provides `reader.json()`, `reader.csv()`, and `reader.raw()`
+methods that return found/not-found results instead of raising exceptions on
+missing files. This eliminates the error cascade where missing DDP files
+produced multiple spurious error log lines.
+
+## PayloadFile
+
+File delivery changed from WORKERFS (mounting files into Pyodide's virtual
+filesystem) to PayloadFile (streaming via FileReaderSync). However,
+**ScriptWrapper auto-materializes PayloadFile uploads to `/tmp`** and converts
+the payload type, so most scripts work without changes.
+
+You only need to update code if you explicitly check for `PayloadString`:
+
+```python
+# Before
+if fileResult.__type__ == "PayloadString":
+
+# After — either works
+if fileResult.__type__ == "PayloadFile":
+# or (ScriptWrapper converts for you):
+if fileResult.__type__ == "PayloadString":
+```
+
+If you use FlowBuilder, this is handled automatically.
+
+## Logging
+
+Python `logging.getLogger()` calls still work for local diagnostics — log
+output appears in the browser console. However, these logs are **not forwarded
+to the host platform**.
+
+For host-visible milestones (operational observability), use explicit
+`CommandSystemLog` yields via the `port_helpers.emit_log()` helper:
+
+```python
+import port.helpers.port_helpers as ph
+
+yield from ph.emit_log("info", f"[{platform}] Extraction complete: {len(tables)} tables")
+```
+
+Host-visible log messages must be **PII-free** — no participant data, file
+paths, or data values. See `docs/decisions/python-architecture/AD0011`.
+
+## Donation key format
+
+Donation keys changed from `{session_id}` to `{session_id}-{platform_name}`.
+If your downstream data pipeline parses donation keys, update the parsing logic.
+
+FlowBuilder handles this automatically. If you build keys manually:
+
+```python
+# Before
+yield donate(f"{session_id}-mykey", data)
+
+# After
+yield donate(f"{session_id}-{platform_name.lower()}", data)
+```
+
+## Testing your migration
+
+```sh
+pnpm doctor          # check environment (13 checks)
+pnpm test            # run 74 Python tests
+pnpm start           # local dev server at localhost:3000
+pnpm run build       # full production build
+```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 The data donation task (a fork of [Feldspar](https://github.com/eyra/feldspar)) is a front end that guides participants through the data donation steps, used in conjunction with Next.
 Next is a software as a service platform developed by [Eyra](https://eyra.co/) to facilitate scientific research.
 
-This repository is based on the [d3i data donation task](https://github.com/d3i-infra/data-donation-task).
-Please see that repository and their [documentation](https://d3i-infra.github.io/data-donation-task/) for general information.
+For detailed tutorials and API reference, see the [documentation site](https://d3i-infra.github.io/data-donation-task/).
+
+### What's new in v2.0.0
+
+The extraction architecture has been consolidated around **FlowBuilder** — a standard template for per-platform donation flows. All 10 platforms have been updated with bilingual headers, improved error handling, and deterministic file resolution. The bridge layer now supports PayloadFile, structured logging, and async donation responses.
+
+See [CHANGELOG.md](CHANGELOG.md) for the full list of changes and [MIGRATION.md](MIGRATION.md) for upgrading downstream forks.
 
 ## Installation and local testing
 

--- a/doc/source/api/api.md
+++ b/doc/source/api/api.md
@@ -27,3 +27,17 @@
 .. automodule:: port.helpers.validate
    :members:
 ```
+
+## FlowBuilder
+
+```{eval-rst}
+.. automodule:: port.helpers.flow_builder
+   :members:
+```
+
+## Upload safety
+
+```{eval-rst}
+.. automodule:: port.helpers.uploads
+   :members:
+```

--- a/doc/source/architecture/01-overview.md
+++ b/doc/source/architecture/01-overview.md
@@ -1,0 +1,100 @@
+# System Overview
+
+The data donation task is a web application that runs entirely inside a
+participant's browser. It guides a participant through uploading their data
+download package (DDP), extracts the relevant data locally using Python, shows
+the participant what will be shared, and — with their consent — sends the
+extracted data to a researcher's storage.
+
+---
+
+## Relationship with Eyra mono
+
+The task runs as an **iframe** embedded in [Eyra mono](https://next.eyra.co/),
+the host platform. The two communicate via a **MessageChannel** established
+at startup: mono sends a `live-init` message with a `MessagePort`; the
+iframe uses that port for all subsequent communication.
+
+```mermaid
+flowchart LR
+    subgraph Browser
+        subgraph Iframe["Data donation task (iframe)"]
+            PY["Pyodide WebWorker\nPython"]
+            JS["JS Framework\nReact + TypeScript"]
+            BR["Bridge\nLiveBridge"]
+            PY -- "Commands" --> JS
+            JS -- "send / sendLogs" --> BR
+        end
+        Mono["Eyra mono\n(host page)"]
+    end
+    BR -- "port.postMessage()\nMessageChannel" --> Mono
+
+    Participant(("Participant")) -- "interacts" --> Iframe
+    Mono -- "stores donations\nserves pages" --> Storage[("Researcher\nstorage")]
+```
+
+In local development, `FakeBridge` replaces `LiveBridge`. It logs commands
+to the console and POSTs donations to a local `/data-submission` endpoint,
+so the full flow can be tested without a running Eyra instance.
+
+---
+
+## Main components
+
+### Pyodide WebWorker
+
+A standard browser [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)
+that loads [Pyodide](https://pyodide.org/) — a Python runtime compiled to
+WebAssembly. The port Python package is installed inside it at startup.
+
+The worker runs the donation script (`script.py`). Because it is a separate
+thread, it cannot block the UI.
+
+**Key file:** `packages/data-collector/public/py_worker.js`
+
+### JS Framework
+
+Runs on the browser's main thread. Responsible for:
+
+- Managing the worker lifecycle (`WorkerProcessingEngine`)
+- Routing commands from Python to the bridge or to the React UI (`CommandRouter`)
+- Rendering interactive pages (`ReactEngine`)
+- Capturing and forwarding JavaScript-side log entries (`LogForwarder`, `WindowLogSource`)
+- Wiring all of the above together (`Assembly`)
+
+**Key files:** `packages/feldspar/src/framework/`
+
+### The bridge
+
+An abstraction layer with two implementations:
+
+| | `LiveBridge` | `FakeBridge` |
+|---|---|---|
+| Used in | Production | Dev / test |
+| Transport | `MessagePort.postMessage()` to Eyra mono | Console log + HTTP POST to `/data-submission` |
+| File | `packages/feldspar/src/live_bridge.ts` | `packages/feldspar/src/fake_bridge.ts` |
+
+Both implement the same `Bridge` interface: `send(command)` for Python-originated
+commands, and `sendLogs(entries)` for JS-side log entries.
+
+### Python packages
+
+| Package | Purpose |
+|---|---|
+| `port.script` | Entry point — `process()` iterates through platforms |
+| `port.helpers.flow_builder` | `FlowBuilder` base class — per-platform flow orchestration |
+| `port.helpers.validate` | `ValidateInput`, `DDPCategory` — zip structure validation |
+| `port.helpers.uploads` | File materialization and safety checks |
+| `port.helpers.extraction_helpers` | `ZipArchiveReader` and CSV/JSON parsing utilities |
+| `port.helpers.port_helpers` | `emit_log`, `render_page`, `donate` and other helpers |
+| `port.api.commands` | `CommandSystem*` and `CommandUIRender` classes |
+| `port.api.d3i_props` | `ExtractionResult`, consent form table types |
+| `port.api.props` | Core UI prop types (`Translatable`, `PropsUIHeader`, etc.) |
+| `port.platforms.*` | Per-platform `FlowBuilder` subclasses |
+| `port.main` | `ScriptWrapper` and `error_flow` — the exception safety layer |
+
+---
+
+## Next
+
+→ [The run cycle](02-run-cycle.md) — how Python and JavaScript take turns

--- a/doc/source/architecture/01-overview.md
+++ b/doc/source/architecture/01-overview.md
@@ -52,17 +52,38 @@ thread, it cannot block the UI.
 
 **Key file:** `packages/data-collector/public/py_worker.js`
 
-### JS Framework
+### JS Framework (feldspar)
 
-Runs on the browser's main thread. Responsible for:
+The framework library. Runs on the browser's main thread. Responsible for:
 
 - Managing the worker lifecycle (`WorkerProcessingEngine`)
 - Routing commands from Python to the bridge or to the React UI (`CommandRouter`)
-- Rendering interactive pages (`ReactEngine`)
+- Rendering interactive pages (`ReactEngine`) via a pluggable factory system
 - Capturing and forwarding JavaScript-side log entries (`LogForwarder`, `WindowLogSource`)
 - Wiring all of the above together (`Assembly`)
+- Providing base UI components and default prompt factories
+
+feldspar is a library — it does not run on its own.
 
 **Key files:** `packages/feldspar/src/framework/`
+
+### Application layer (data-collector)
+
+The Vite app that gets built and served. This is the composition root that
+wires feldspar together with D3I-specific components:
+
+- Hosts `py_worker.js` (the worker entry point) and the Python wheel
+  (`port-0.0.0.tar.gz`) in its `public/` directory
+- Registers custom prompt factories for D3I UI components (consent form with
+  visualizations, multi-file input, questionnaire, error page, retry prompt)
+- Configures `ScriptHostComponent` with the worker URL, log level, and
+  standalone/production toggle
+- Manages the iframe lifecycle (app-loaded signal, resize observer)
+
+See [Rendering and the factory system](08-rendering.md) for how data-collector
+plugs into feldspar's rendering pipeline.
+
+**Key files:** `packages/data-collector/src/App.tsx`, `packages/data-collector/public/`
 
 ### The bridge
 

--- a/doc/source/architecture/02-run-cycle.md
+++ b/doc/source/architecture/02-run-cycle.md
@@ -1,0 +1,122 @@
+# The Run Cycle
+
+The data donation task is built on a **co-routine pattern**: Python and
+JavaScript take turns. Python runs until it has something to show the
+participant or something to send to the host, then it yields a command and
+pauses. JavaScript handles the command, waits for a response (user interaction
+or a host acknowledgement), and sends that response back to Python. Python
+resumes with the response as the return value of the `yield`.
+
+This alternation is the heartbeat of the whole system. Every UI interaction,
+every log message, every donation — all of it goes through this cycle.
+
+---
+
+## Startup sequence
+
+Before the first run cycle can happen, Pyodide must be loaded and the port
+package installed. This takes several seconds on first load.
+
+```mermaid
+sequenceDiagram
+    participant MONO as Eyra mono
+    participant SHC as ScriptHostComponent
+    participant ASM as Assembly
+    participant WPE as WorkerProcessingEngine
+    participant WK as py_worker.js
+
+    MONO->>SHC: postMessage live-init (MessagePort, locale)
+    SHC->>ASM: LiveBridge.create() callback
+    ASM->>WPE: processingEngine.start()
+    WPE->>WK: postMessage initialise
+    WK->>WK: loadPyodide()
+    WK->>WK: loadPackage([micropip, numpy, pandas])
+    WK->>WK: micropip.install(port-*.whl)
+    WK->>WPE: postMessage initialiseDone
+    WPE->>MONO: sendSystemEvent("initialized")
+    WPE->>WK: postMessage firstRunCycle (sessionId, platform)
+    WK->>WK: pyScript = port.start(sessionId, platform)
+    WK->>WK: runCycle(null)
+    WK->>WPE: postMessage runCycleDone (first command)
+```
+
+`port.start(sessionId, platform)` calls `main.start()`, which creates a
+`ScriptWrapper` around `script.process()`. The `ScriptWrapper` is a Python
+generator. `runCycle(null)` calls `pyScript.send(null)` — the first send to a
+generator must pass `None`, which advances it to its first `yield`.
+
+---
+
+## The run cycle loop
+
+After startup, every cycle follows the same pattern:
+
+```mermaid
+sequenceDiagram
+    participant WPE as WorkerProcessingEngine
+    participant CR as CommandRouter
+    participant RE as ReactEngine
+    participant BR as Bridge
+    participant WK as py_worker.js
+    participant PY as Python (ScriptWrapper)
+
+    WPE->>CR: onCommand(command)
+
+    alt CommandUIRender
+        CR->>RE: visualizationEngine.render(page)
+        RE-->>CR: response (PayloadTrue/False/JSON/File)
+        CR-->>WPE: response
+    else CommandSystemDonate / CommandSystemLog / CommandSystemExit
+        CR->>BR: bridge.send(command)
+        BR-->>CR: response (PayloadVoid or PayloadResponse)
+        CR-->>WPE: response
+    end
+
+    WPE->>WK: postMessage nextRunCycle (response)
+    WK->>PY: pyScript.send(response.payload)
+    PY-->>WK: next command (via yield)
+    WK->>WPE: postMessage runCycleDone (command)
+    WPE->>WPE: logger.flush()
+```
+
+The cycle ends when Python raises `StopIteration` (the generator is
+exhausted), at which point `ScriptWrapper.send()` returns
+`CommandSystemExit(0, "End of script")`.
+
+---
+
+## File handling in the worker
+
+When the user selects a file, the response payload is `PayloadFile`, which
+contains a browser `File` object. Browser `File` objects cannot be passed
+directly into Python — they live in the JS thread and Python runs in the
+worker thread.
+
+The worker handles this in `unwrap()`:
+
+1. JS sends `nextRunCycle` with `response.payload.__type__ == "PayloadFile"`
+2. `py_worker.js` wraps the `File` in a `FileReaderSync`-backed reader object
+3. This reader is sent to Python as a `PayloadFile.value`
+4. Python's `AsyncFileAdapter` wraps it, allowing synchronous `.read()` inside the worker
+5. `uploads.materialize_file()` writes the bytes to `/tmp` in Emscripten's in-memory filesystem
+
+The `/tmp` filesystem is in-memory and scoped to the worker — no data is
+written to the participant's disk, and it is freed when the worker terminates.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `packages/data-collector/public/py_worker.js` | Worker entry point, `runCycle()`, `unwrap()` |
+| `packages/feldspar/src/framework/processing/worker_engine.ts` | `WorkerProcessingEngine` |
+| `packages/feldspar/src/framework/command_router.ts` | `CommandRouter` |
+| `packages/feldspar/src/framework/assembly.ts` | Wires all JS components |
+| `packages/python/port/main.py` | `ScriptWrapper`, `start()` |
+| `packages/python/port/api/file_utils.py` | `AsyncFileAdapter` |
+| `packages/python/port/helpers/uploads.py` | `materialize_file()` |
+
+---
+
+→ [Command protocol](03-command-protocol.md) — what Python can yield and what comes back

--- a/doc/source/architecture/03-command-protocol.md
+++ b/doc/source/architecture/03-command-protocol.md
@@ -1,0 +1,119 @@
+# Command Protocol
+
+Every interaction between Python and the rest of the system goes through a
+**command**. Python yields a command object; `ScriptWrapper.send()` serialises
+it to a dict via `.toDict()`; the worker posts it to the JS thread; and the
+JS framework handles it and returns a response that Python receives as the
+return value of the `yield`.
+
+All command classes live in `packages/python/port/api/commands.py`. Their
+TypeScript counterparts are in
+`packages/feldspar/src/framework/types/commands.ts`.
+
+---
+
+## Command types
+
+### `CommandUIRender`
+
+Tells the JS framework to render a page and wait for the participant to
+interact with it.
+
+```
+Python:  yield CommandUIRender(page)
+Returns: a Payload* matching the UI component shown
+```
+
+| Response type | When returned |
+|---|---|
+| `PayloadFile` | Participant selected a file |
+| `PayloadString` | File delivered via WORKERFS path (legacy) |
+| `PayloadTrue` | Participant clicked the "ok" / confirm button |
+| `PayloadFalse` | Participant clicked the "cancel" / decline button |
+| `PayloadJSON` | Participant submitted a consent form or questionnaire |
+| `PayloadVoid` | Error or unexpected state in the renderer |
+
+In practice, `ph.render_page(header, body)` wraps this — you rarely yield
+`CommandUIRender` directly.
+
+---
+
+### `CommandSystemDonate`
+
+Sends a key/value pair to the host for storage.
+
+```
+Python:  yield CommandSystemDonate(key, json_string)
+Returns: PayloadVoid (fire-and-forget, older hosts)
+         PayloadResponse (newer hosts with VITE_ASYNC_DONATIONS=true)
+```
+
+`PayloadResponse.value` has the shape `{ success: bool, key: str, status: int, error?: str }`.
+`port_helpers.handle_donate_result()` normalises both response types into a
+single `bool`.
+
+The donation key is conventionally `"{session_id}-{platform_name}"`, e.g.
+`"1741234567890-linkedin"`. The `json_string` is whatever the participant
+consented to share.
+
+---
+
+### `CommandSystemLog`
+
+Sends a log message to the host. The host forwards it to its logging
+infrastructure (Eyra mono routes these to `/api/feldspar/log`).
+
+```
+Python:  yield CommandSystemLog(level, message)
+Returns: PayloadVoid (always — the response is discarded)
+```
+
+Use via `yield from ph.emit_log(level, message)`. Messages **must be
+PII-free** — error counts and milestone strings only. See
+[Logging](06-logging.md) for the full rules.
+
+---
+
+### `CommandSystemExit`
+
+Signals that the script has finished. The JS engine does not send a
+`nextRunCycle` after receiving this — the run loop halts.
+
+```
+Python:  yield CommandSystemExit(code, info)
+Returns: (nothing — the promise never resolves; the loop stops)
+```
+
+`ScriptWrapper.send()` raises `StopIteration` when the generator is
+exhausted, and returns `CommandSystemExit(0, "End of script")` automatically.
+You should not yield this manually from `FlowBuilder` flows.
+
+---
+
+## Serialisation
+
+Every command class has a `.toDict()` method that produces a plain dict with
+a `__type__` field. The worker passes this to the JS thread via
+`postMessage()`, which uses the structured clone algorithm (no manual
+JSON serialisation needed for most types).
+
+The TypeScript side uses type guard functions (`isCommandSystemLog()`, etc.)
+in `commands.ts` to narrow the type before routing.
+
+---
+
+## Response types
+
+| Type | Fields | Produced by |
+|---|---|---|
+| `PayloadFile` | `value: File` | File input prompt |
+| `PayloadString` | `value: string` | WORKERFS file path (legacy) |
+| `PayloadTrue` | — | Confirm / ok button |
+| `PayloadFalse` | — | Cancel / decline button |
+| `PayloadJSON` | `value: string` | Consent form, questionnaire |
+| `PayloadVoid` | — | Host acknowledgement (fire-and-forget) |
+| `PayloadResponse` | `value: { success, key, status, error? }` | Host donation result (async mode) |
+
+---
+
+→ [FlowBuilder](04-flowbuilder.md) — how Python uses these commands to drive a donation flow

--- a/doc/source/architecture/04-flowbuilder.md
+++ b/doc/source/architecture/04-flowbuilder.md
@@ -1,0 +1,157 @@
+# FlowBuilder
+
+`FlowBuilder` is the base class for every per-platform donation flow. It
+owns the complete lifecycle of a single platform's donation: prompting for
+a file, validating it, extracting data, presenting a consent form, and
+donating the result.
+
+**File:** `packages/python/port/helpers/flow_builder.py`
+
+---
+
+## How it fits in
+
+`script.py` is the study-level orchestrator. It iterates through a registry
+of platforms and for each one creates a `FlowBuilder` subclass instance and
+calls `yield from flow.start_flow()`. The per-platform flow runs completely
+before the next platform begins.
+
+```mermaid
+flowchart LR
+    subgraph script.py
+        P["process(session_id, platform)"]
+    end
+    subgraph platforms
+        LI["LinkedInFlow"]
+        IG["InstagramFlow"]
+        FB["FacebookFlow"]
+        OT["... (10 platforms)"]
+    end
+    subgraph FlowBuilder
+        SF["start_flow()"]
+    end
+
+    P -- "yield from" --> LI & IG & FB & OT
+    LI & IG & FB & OT -- "inherits" --> SF
+```
+
+---
+
+## The 11-step flow
+
+`start_flow()` is a generator that implements a fixed lifecycle. It loops
+so the participant can retry file selection, and breaks out of the loop once
+extraction succeeds.
+
+```mermaid
+flowchart TD
+    A["1. Render file prompt\nCommandUIRender + PropsUIPromptFileInput"]
+    B{"PayloadFile\nor PayloadString?"}
+    C["2. Materialize file\nuploads.materialize_file()"]
+    D["3. Safety check\nuploads.check_file_safety()"]
+    E{"Safe?"}
+    F["Render safety error page\nreturn"]
+    G["4. Validate\nself.validate_file(path)"]
+    H{"Valid?\nstatus == 0"}
+    I["5. Retry prompt\nCommandUIRender + PropsUIPromptConfirm"]
+    J{"Try again?"}
+    K["6. Extract\nself.extract_data(path, validation)"]
+    L["7. Log extraction summary\nph.emit_log() — counts only"]
+    M{"Any tables?"}
+    N["Render no-data page\nreturn"]
+    O["8. Render consent form\nCommandUIRender + PropsUIPromptConsentFormViz"]
+    P{"PayloadJSON\nor PayloadFalse?"}
+    Q["9. Donate\nCommandSystemDonate(session_id-platform, json)"]
+    R{"Donation\nsucceeded?"}
+    S["Render failure page\nreturn"]
+    T["Flow complete\nreturn"]
+
+    A --> B
+    B -- "no payload" --> T
+    B -- "yes" --> C --> D --> E
+    E -- "no" --> F
+    E -- "yes" --> G --> H
+    H -- "no" --> I --> J
+    J -- "PayloadTrue" --> A
+    J -- "PayloadFalse" --> T
+    H -- "yes" --> K --> L --> M
+    M -- "no tables" --> N
+    M -- "yes" --> O --> P
+    P --> Q --> R
+    R -- "failed + not decline" --> S
+    R -- "success or decline" --> T
+```
+
+---
+
+## Emit log milestones
+
+`start_flow()` calls `ph.emit_log()` at each significant step. These are the
+messages that appear in the host's log stream. They are always PII-free —
+platform name, status code, and counts, never participant data.
+
+| Step | Log message |
+|---|---|
+| File received | `[Platform] File received: N bytes, PayloadFile` |
+| Safety check failed | `[Platform] Safety check failed: FileTooLargeError` |
+| Validation passed | `[Platform] Validation: valid (category_id)` |
+| Validation failed | `[Platform] Validation: invalid` |
+| Extraction complete | `[Platform] Extraction complete: N tables, M rows; errors: ErrorType×count` |
+| Consent form shown | `[Platform] Consent form shown` |
+| Consent accepted | `[Platform] Consent: accepted` |
+| Consent declined | `[Platform] Consent: declined` |
+| Donation started | `[Platform] Donation started: payload size=N bytes` |
+| Donation result | `[Platform] Donation result: success/failed` |
+
+---
+
+## Implementing a platform
+
+Subclass `FlowBuilder` and implement two methods:
+
+```python
+class LinkedInFlow(FlowBuilder):
+    def __init__(self, session_id: str):
+        super().__init__(session_id, "LinkedIn")  # sets self.platform_name
+
+    def validate_file(self, file: str) -> validate.ValidateInput:
+        return validate.validate_zip(DDP_CATEGORIES, file)
+
+    def extract_data(self, file: str, validation: validate.ValidateInput) -> ExtractionResult:
+        return extraction(file, validation)
+```
+
+- `validate_file(path)` — returns a `ValidateInput`. Status 0 = valid; non-zero = invalid.
+- `extract_data(path, validation)` — returns an `ExtractionResult`. Can also be a generator
+  (`yield from`) if you need to yield intermediate commands during extraction.
+
+Everything else — the file prompt, the retry loop, the consent form, the
+donation, the logging — is handled by `start_flow()`.
+
+---
+
+## UI text
+
+`FlowBuilder.__init__()` calls `_initialize_ui_text()`, which builds a dict
+of `Translatable` strings for the file prompt header, consent form header,
+retry header, and review description. These are constructed from
+`self.platform_name` so they automatically use the platform name you pass to
+`super().__init__()`.
+
+Override `_initialize_ui_text()` or modify `self.UI_TEXT` after `super().__init__()`
+if you need custom text.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `packages/python/port/helpers/flow_builder.py` | `FlowBuilder` base class |
+| `packages/python/port/script.py` | `process()` — iterates platforms |
+| `packages/python/port/platforms/linkedin.py` | Example platform implementation |
+| `packages/python/port/helpers/port_helpers.py` | `emit_log`, `render_page`, `donate` helpers |
+
+---
+
+→ [Extraction](05-extraction.md) — how `extract_data()` works inside a platform

--- a/doc/source/architecture/05-extraction.md
+++ b/doc/source/architecture/05-extraction.md
@@ -1,0 +1,155 @@
+# Extraction
+
+Extraction is the step where Python reads the participant's DDP (Data Donation
+Package), parses the files it needs, and produces a set of tables for the
+participant to review. This happens entirely inside the Pyodide WebWorker —
+no data leaves the browser until the participant explicitly consents.
+
+---
+
+## Validation first
+
+Before extraction begins, `FlowBuilder.start_flow()` calls `self.validate_file(path)`.
+Validation answers: *is this the right kind of file?*
+
+```mermaid
+flowchart LR
+    Z["zip file\nfrom participant"]
+    VZ["validate.validate_zip(\n  DDP_CATEGORIES,\n  path\n)"]
+    VI["ValidateInput"]
+    S0{"status == 0?"}
+    OK["extraction proceeds\nvalidation.archive_members\npassed to ZipArchiveReader"]
+    FAIL["invalid → retry prompt"]
+
+    Z --> VZ --> VI --> S0
+    S0 -- yes --> OK
+    S0 -- no --> FAIL
+```
+
+`validate_zip()` opens the zip and inspects its file list against a platform's
+`DDP_CATEGORIES` — a list of `DDPCategory` objects, each specifying an expected
+set of filenames, language, and file type. If enough known files are present,
+status 0 is set and `validation.archive_members` is populated with the full
+member list.
+
+---
+
+## ZipArchiveReader
+
+`ZipArchiveReader` is the main tool for reading files out of a validated zip.
+It is constructed with the zip path, the member list from validation, and a
+shared `errors` Counter:
+
+```python
+reader = ZipArchiveReader(linkedin_zip, validation.archive_members, errors)
+```
+
+It provides two main methods:
+
+| Method | Returns | Use for |
+|---|---|---|
+| `reader.csv("filename.csv")` | `ReadResult` with a `pd.DataFrame` | CSV files |
+| `reader.raw("filename.csv")` | `ReadResult` with `io.BytesIO` | Files needing pre-processing before parsing |
+
+Both return a `ReadResult` with a `found: bool` field. If the file is not in
+the zip, `found` is `False` and no error is recorded. This is the standard
+pattern for optional files:
+
+```python
+result = reader.csv("Company Follows.csv")
+if not result.found:
+    return pd.DataFrame()   # silently skip
+return result.data
+```
+
+When a file is found but cannot be parsed (malformed CSV, encoding error, etc.),
+`ZipArchiveReader` catches the exception, increments `errors[ExceptionType.__name__]`,
+and returns an empty `DataFrame`. This keeps extraction running even when
+individual files fail.
+
+**File:** `packages/python/port/helpers/extraction_helpers.py`
+
+---
+
+## ExtractionResult
+
+`extract_data()` must return an `ExtractionResult`:
+
+```python
+@dataclass
+class ExtractionResult:
+    tables: list[PropsUIPromptConsentFormTableViz]
+    errors: Counter = field(default_factory=Counter)
+```
+
+- `tables` — the data to show the participant in the consent form. Each table
+  has an `id`, a `title`, a `data_frame`, and optional `description`,
+  `visualizations`, and `headers`.
+- `errors` — a `Counter` of exception type names. Keys are class names only
+  (e.g. `"KeyError"`, `"FileNotFoundInZipError"`); no messages, no tracebacks.
+
+`FlowBuilder.start_flow()` reads `result.errors` after extraction and formats
+it into a PII-free log message: `"errors: KeyError×3, FileNotFoundInZipError×1"`.
+
+---
+
+## The extraction pattern
+
+A typical platform's `extract_data()` function follows this pattern:
+
+```python
+def extraction(zip_path: str, validation: ValidateInput) -> ExtractionResult:
+    errors = Counter()
+    reader = ZipArchiveReader(zip_path, validation.archive_members, errors)
+
+    tables = [
+        PropsUIPromptConsentFormTableViz(
+            id="linkedin_connections",
+            data_frame=connections_to_df(reader, errors),
+            title=Translatable({"en": "Your connections", "nl": "Uw connecties"}),
+            ...
+        ),
+        ...
+    ]
+
+    return ExtractionResult(
+        tables=[t for t in tables if not t.data_frame.empty],
+        errors=errors,
+    )
+```
+
+Each per-file function (`connections_to_df`, etc.) receives the shared `errors`
+Counter so it can record failures without interrupting extraction of other files.
+The `if not t.data_frame.empty` filter ensures empty tables are not shown to
+the participant.
+
+---
+
+## DDPCategory and known files
+
+Each platform defines a list of `DDP_CATEGORIES`. A `DDPCategory` specifies:
+
+- `id` — a string identifier (e.g. `"csv_en"`)
+- `ddp_filetype` — `DDPFiletype.CSV`, `.JSON`, `.HTML`, etc.
+- `language` — `Language.EN`, `.NL`, etc.
+- `known_files` — a list of filenames expected in this DDP variant
+
+Validation succeeds if a sufficient proportion of `known_files` are present
+in the zip. If a platform exports in multiple formats (e.g. English JSON,
+Dutch HTML), define multiple `DDPCategory` entries and validation picks the
+matching one. `validation.current_ddp_category` tells you which category matched.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `packages/python/port/helpers/extraction_helpers.py` | `ZipArchiveReader`, `ReadResult` |
+| `packages/python/port/helpers/validate.py` | `ValidateInput`, `DDPCategory`, `validate_zip()` |
+| `packages/python/port/api/d3i_props.py` | `ExtractionResult`, `PropsUIPromptConsentFormTableViz` |
+| `packages/python/port/platforms/linkedin.py` | Complete example extraction implementation |
+
+---
+
+→ [Logging](06-logging.md) — how extraction errors and milestones reach the host

--- a/doc/source/architecture/06-logging.md
+++ b/doc/source/architecture/06-logging.md
@@ -1,0 +1,141 @@
+# Logging
+
+Log messages reach the host (Eyra mono's `/api/feldspar/log`) via two
+separate paths. Understanding which path a message takes, and why, is
+important for knowing what the host will see and what PII rules apply.
+
+---
+
+## Two paths to the host
+
+```mermaid
+sequenceDiagram
+    participant FB as FlowBuilder<br/>flow_builder.py
+    participant SW as ScriptWrapper<br/>main.py
+    participant WB as Worker boundary<br/>py_worker.js
+    participant WPE as WorkerProcessingEngine<br/>worker_engine.ts
+    participant LF as LogForwarder<br/>logging.ts
+    participant CR as CommandRouter<br/>command_router.ts
+    participant LB as LiveBridge<br/>live_bridge.ts
+    participant HOST as Eyra mono
+
+    note over FB,SW: Path A — Python emit_log
+
+    FB->>SW: yield CommandSystemLog(level, message)
+    SW->>WB: postMessage runCycleDone
+    WB->>WPE: handleEvent('runCycleDone')
+    WPE->>CR: handleRunCycle → onCommand(CommandSystemLog)
+    CR->>LB: bridge.send(command)
+    LB->>HOST: port.postMessage(CommandSystemLog)
+    WPE->>LF: logger.flush()
+
+    note over WPE,LF: Path B — JS LogForwarder
+
+    WPE->>LF: worker.onerror → logger.log('error', ...)
+    LF->>LB: flush → sendLogs(entries)
+    LB->>HOST: port.postMessage(CommandSystemLog ×N)
+```
+
+---
+
+## Path A: Python `emit_log`
+
+**Origin:** Python code explicitly calls `yield from ph.emit_log(level, message)`.
+
+**Route:**
+1. `ph.emit_log()` yields a `CommandSystemLog(level, message)`
+2. `ScriptWrapper.send()` serialises it via `.toDict()` and returns it
+3. `py_worker.js` posts `runCycleDone` with the command dict
+4. `WorkerProcessingEngine.handleRunCycle()` passes it to `CommandRouter`
+5. `CommandRouter.onCommandSystem()` calls `bridge.send(command)`
+6. `LiveBridge.send()` calls `port.postMessage(command)` — the message arrives at Eyra mono
+
+**PII rule:** All messages on Path A **must be PII-free**. This means:
+- Error counts from `ExtractionResult.errors` (type names and counts only)
+- Flow milestone strings (e.g. `[LinkedIn] Consent: accepted`)
+- File size in bytes
+- No exception messages, no file paths, no participant data
+
+**Where to use it:** In `FlowBuilder.start_flow()` and `script.py`. Already
+called for you at every standard milestone — you only need to add custom
+`emit_log` calls if you add non-standard flow steps.
+
+---
+
+## Path B: JS `LogForwarder`
+
+**Origin:** JavaScript-side errors and infrastructure events.
+
+**Sources that feed into `LogForwarder`:**
+
+| Source | What it captures |
+|---|---|
+| `WindowLogSource` | `window.error` events, unhandled promise rejections |
+| `WorkerProcessingEngine.worker.onerror` | Pyodide worker crashes (distinct from Python exceptions) |
+| `WorkerProcessingEngine` internal | Worker lifecycle events at `debug` level |
+
+**Route:**
+1. Error is captured by `WindowLogSource` or `WorkerProcessingEngine`
+2. `LogForwarder.log(level, message, context)` adds it to an in-memory buffer
+3. Error-level entries trigger an immediate `flush()`; all other levels flush
+   after each run cycle
+4. The flush callback (wired in `Assembly`) calls `bridge.sendLogs(entries)`
+5. `LiveBridge.sendLogs()` formats each entry as a `CommandSystemLog`-shaped
+   `postMessage` and posts it to the host
+
+**PII rule:** Path B carries context objects (memory usage, filename, line
+number) but no participant data. Raw Python tracebacks **never** reach Path B
+— that is handled by [error_flow](07-error-handling.md) instead.
+
+---
+
+## What stays local
+
+Not everything is forwarded to the host. The standard Python `logging` module
+(via `logger = logging.getLogger(__name__)`) writes to the Pyodide worker's
+`stderr`, which appears in the browser's DevTools console. This is the place
+for verbose diagnostic detail — full exception messages, intermediate values,
+file contents. It never leaves the participant's browser.
+
+| Where | What it contains | Visible to host? |
+|---|---|---|
+| `emit_log` (Path A) | PII-free milestones and error counts | Yes |
+| `LogForwarder` (Path B) | JS errors, worker crashes, context | Yes |
+| `logger.info/error(...)` (Python logging) | Full diagnostic detail | No — browser console only |
+
+---
+
+## `CommandSystemLog` format
+
+```python
+# Python
+CommandSystemLog(level="info", message="[LinkedIn] Consent: accepted").toDict()
+
+# Produces:
+{
+    "__type__": "CommandSystemLog",
+    "level": "info",
+    "message": "[LinkedIn] Consent: accepted",
+    "json_string": '{"level": "info", "message": "[LinkedIn] Consent: accepted"}'
+}
+```
+
+`json_string` is a temporary field for backwards compatibility with older Eyra
+mono versions that expect it. It will be removed once the host is updated.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `packages/python/port/helpers/port_helpers.py` | `emit_log()` |
+| `packages/python/port/api/commands.py` | `CommandSystemLog.toDict()` |
+| `packages/feldspar/src/framework/logging.ts` | `LogForwarder`, `WindowLogSource` |
+| `packages/feldspar/src/framework/processing/worker_engine.ts` | Flush trigger, `worker.onerror` |
+| `packages/feldspar/src/framework/assembly.ts` | Wires `LogForwarder` flush callback to bridge |
+| `packages/feldspar/src/live_bridge.ts` | `sendLogs()`, `send()` |
+
+---
+
+→ [Error handling](07-error-handling.md) — what happens when Python throws an unhandled exception

--- a/doc/source/architecture/06-logging.md
+++ b/doc/source/architecture/06-logging.md
@@ -68,11 +68,18 @@ called for you at every standard milestone — you only need to add custom
 
 **Sources that feed into `LogForwarder`:**
 
-| Source | What it captures |
-|---|---|
-| `WindowLogSource` | `window.error` events, unhandled promise rejections |
-| `WorkerProcessingEngine.worker.onerror` | Pyodide worker crashes (distinct from Python exceptions) |
-| `WorkerProcessingEngine` internal | Worker lifecycle events at `debug` level |
+| Source | Scope | What it captures |
+|---|---|---|
+| `WindowLogSource` `error` listener | Main thread (`window`) | Synchronous JS errors on the main thread |
+| `WindowLogSource` `unhandledrejection` listener | Main thread (`window`) | Unhandled promise rejections on the main thread only — **not** in the worker |
+| `WorkerProcessingEngine.worker.onerror` | Main thread (listening on worker) | Synchronous worker errors that propagate to the main thread |
+| `WorkerProcessingEngine` internal | Main thread | Worker lifecycle events at `debug` level |
+
+**Scope gap:** Unhandled promise rejections inside the worker (e.g. an
+`unwrap()` failure in `py_worker.js`) are not captured by any of these
+sources. `WindowLogSource` listens on `window`, not the worker's global scope.
+These rejections are silently lost — visible only in the worker's DevTools
+console.
 
 **Route:**
 1. Error is captured by `WindowLogSource` or `WorkerProcessingEngine`
@@ -83,9 +90,18 @@ called for you at every standard milestone — you only need to add custom
 5. `LiveBridge.sendLogs()` formats each entry as a `CommandSystemLog`-shaped
    `postMessage` and posts it to the host
 
-**PII rule:** Path B carries context objects (memory usage, filename, line
-number) but no participant data. Raw Python tracebacks **never** reach Path B
-— that is handled by [error_flow](07-error-handling.md) instead.
+**PII rule:** `WindowLogSource` captures rich context (memory usage, filename,
+line number) into the `LogEntry`, and `LogForwarder` records a `timestamp`.
+`LiveBridge.sendLogs()` **drops both `context` and `timestamp`** — it only
+posts `level` and `message` to the host (plus a `json_string` duplicate for
+backwards compatibility). The full `LogEntry` exists in the JS runtime's
+`LogForwarder` buffer (visible in DevTools) but those extra fields never cross
+the bridge. Raw Python tracebacks also never reach Path B — that is handled by
+[error_flow](07-error-handling.md) instead.
+
+**Dead handler note:** `WorkerProcessingEngine.handleEvent()` has a case for
+`eventType: 'error'` (a custom worker message), but `py_worker.js` never posts
+this event type. The handler exists but is inert on this branch.
 
 ---
 

--- a/doc/source/architecture/07-error-handling.md
+++ b/doc/source/architecture/07-error-handling.md
@@ -29,11 +29,18 @@ tracebacks, no file contents.
 
 ---
 
-## Category 2: Uncaught Python exceptions
+## Category 2: Uncaught Python exceptions — three defense layers
 
 If an exception escapes `extract_data()` — or any other part of the script
-generator — `ScriptWrapper.send()` catches it before it can propagate into
-the JS engine.
+generator — there are three layers of defense preventing it from reaching the
+host unsanitised. Each layer catches what the previous one missed, with
+decreasing PII protection.
+
+### Layer 1: `ScriptWrapper` (Python) — consent-gated
+
+The primary defense. `ScriptWrapper.send()` wraps every call to the script
+generator in a try/except. If an exception escapes, it is caught in Python
+and routed through `error_flow`.
 
 ```mermaid
 flowchart TD
@@ -68,17 +75,141 @@ flowchart TD
 **What the host sees:** Either nothing, or a full donation payload containing
 the traceback — but only with consent.
 
+**File:** `packages/python/port/main.py`
+
+### Layer 2: `runCycle()` try/catch (JS worker) — shown on screen, not forwarded
+
+If `ScriptWrapper` fails to catch the exception (e.g. a bug in `ScriptWrapper`
+itself, or an error during Pyodide object conversion), it propagates into
+`py_worker.js`. The `runCycle()` function has a try/catch that converts the
+error into a `CommandUIRender` via `generateErrorMessage()`:
+
+```javascript
+// py_worker.js
+function runCycle(payload) {
+  try {
+    scriptEvent = pyScript.send(payload);
+    // ... post runCycleDone with command
+  } catch (error) {
+    self.postMessage({
+      eventType: "runCycleDone",
+      scriptEvent: generateErrorMessage(String(error)),
+    });
+  }
+}
+```
+
+`generateErrorMessage()` constructs a `PropsUIPageDataSubmission` with the
+error text. This is posted as a normal `runCycleDone` event, so it flows
+through `CommandRouter` → `ReactEngine` and is **rendered on screen** — not
+forwarded to the host via the bridge.
+
+**PII note:** The traceback is shown directly to the participant via
+`String(error)` with no consent gate. However, it does not reach the host —
+the command is a `CommandUIRender`, not a `CommandSystemLog` or
+`CommandSystemDonate`.
+
+**File:** `packages/data-collector/public/py_worker.js`
+
+> **Branch note:** This try/catch was added in commit `f0b77fa` (part of
+> `integration/extraction-consolidation`), which builds on
+> `integration/bridge-alignment`. It is not present in `bridge-alignment`
+> itself — the Layer 2 defense is introduced in the next PR in the stack.
+
+### Layer 3: `worker.onerror` (JS main thread) — limited to synchronous errors
+
+`WorkerProcessingEngine` registers a `worker.onerror` handler:
+
+```typescript
+// worker_engine.ts
+this.worker.onerror = (error) => {
+  this.logger?.log('error', `Python error: ${error.message}`, {
+    filename: error.filename,
+    lineno: error.lineno,
+    colno: error.colno,
+  })
+}
+```
+
+This logs to `LogForwarder`, which flushes immediately (error-level entries
+trigger auto-flush), and the message reaches the host via
+`LiveBridge.sendLogs()`.
+
+**However, this only catches synchronous errors.** In `py_worker.js`, there
+are two call sites for `runCycle()`:
+
+- **`firstRunCycle`** — calls `runCycle(null)` synchronously from `onmessage`.
+  If it throws, the error propagates synchronously → `worker.onerror` fires.
+  This only happens once at startup.
+- **`nextRunCycle`** — calls `runCycle(userInput)` inside a `.then()` callback.
+  If it throws, the synchronous throw inside `.then()` becomes a **rejected
+  promise**. There is no `.catch()`. This is an unhandled promise rejection
+  in the worker's global scope — `worker.onerror` on the main thread does
+  **not** fire for these. `WindowLogSource`'s `unhandledrejection` listener
+  is on `window` (main thread), not the worker's global scope.
+
+In practice, every run cycle after the first goes through `nextRunCycle`. So
+for the common case, **an exception escaping both Layer 1 and Layer 2 would
+be silently swallowed** — visible only in the worker's DevTools console,
+never reaching `LogForwarder` or the host.
+
+**File:** `packages/feldspar/src/framework/processing/worker_engine.ts`
+
+### Summary of the three layers
+
+```mermaid
+flowchart TD
+    EX["Python exception thrown"]
+    L1{"Layer 1:\nScriptWrapper\ncatches?"}
+    EF["error_flow\nconsent-gated\nmain.py"]
+    L2{"Layer 2:\nrunCycle() try/catch\ncatches?"}
+    GEM["generateErrorMessage()\nrendered on screen\npy_worker.js"]
+    L3{"firstRunCycle\n(synchronous)?"}
+    OE["worker.onerror fires\nLogForwarder → sendLogs()\nmessage reaches host"]
+    LOST["nextRunCycle:\nunhandled promise rejection\nsilently lost in worker"]
+
+    EX --> L1
+    L1 -- yes --> EF
+    L1 -- no --> L2
+    L2 -- yes --> GEM
+    L2 -- no --> L3
+    L3 -- yes --> OE
+    L3 -- no --> LOST
+```
+
+| Layer | Where | Consent? | Reaches host? |
+|---|---|---|---|
+| 1. `ScriptWrapper` | Python (main.py) | Yes — participant must opt in | Only if consented |
+| 2. `runCycle()` catch | JS worker (py_worker.js) | No — shown on screen directly | No — rendered as UI, not logged |
+| 3. `worker.onerror` | JS main thread (worker_engine.ts) | No | Only for `firstRunCycle` (synchronous); silently lost for `nextRunCycle` (promise rejection) |
+
 ---
 
 ## Category 3: JavaScript-side errors
 
-Errors originating in JavaScript (worker crashes, unhandled promise
-rejections, `window.onerror` events) never touch Python or `error_flow`.
-They go through [Path B of the logging system](06-logging.md#path-b-js-logforwarder)
-directly to the host.
+Errors originating in JavaScript that are not caused by Python exceptions
+never touch `ScriptWrapper` or `error_flow`. They go through
+[Path B of the logging system](06-logging.md#path-b-js-logforwarder), but
+only if they occur in the right scope:
 
-**What the host sees:** Error level log entries with message and context
-(memory usage, filename, line number). No participant data.
+| Error type | Where it fires | Reaches host? |
+|---|---|---|
+| Synchronous main-thread error | `WindowLogSource` `error` listener on `window` | Yes |
+| Unhandled promise rejection on **main thread** | `WindowLogSource` `unhandledrejection` listener on `window` | Yes |
+| Synchronous worker error | `worker.onerror` on main thread | Yes |
+| Unhandled promise rejection **in worker** | Nothing — `window` listeners don't see worker-scope rejections | No — silently lost |
+
+**What the host sees (when it reaches the host):** Error level log entries with
+`level` and `message` only. The context fields captured by `WindowLogSource`
+(memory usage, filename, line number) and the timestamp are dropped by
+`LiveBridge.sendLogs()` and never reach the host.
+
+**Scope gap:** `WindowLogSource` listens on `window` (main thread). The worker
+has its own global scope. An unhandled promise rejection inside the worker
+(e.g. an `unwrap()` failure in `py_worker.js`) does not bubble to the main
+thread's `window` — it is invisible to `WindowLogSource` and `LogForwarder`.
+This is the same gap that affects Layer 3 of Category 2: the worker has no
+`self.addEventListener('unhandledrejection', ...)` handler.
 
 ---
 
@@ -91,18 +222,26 @@ host without consent.
 | Path | Raw exception text reaches host? |
 |---|---|
 | `emit_log` (Path A) | No — counts and type names only |
-| `LogForwarder` (Path B) | No — JS errors only, no Python tracebacks |
-| `error_flow` donation | Only with explicit participant consent |
+| `error_flow` (Layer 1) | Only with explicit participant consent |
+| `runCycle()` catch (Layer 2) | No — rendered on screen, not forwarded |
+| `worker.onerror` (Layer 3, `firstRunCycle` only) | Yes — forwarded via `LogForwarder`, but only for the synchronous first cycle |
+| Escaped exception in `nextRunCycle` | No — silently lost as unhandled promise rejection in worker |
+| `LogForwarder` (Path B, main-thread JS errors) | Message only (context and timestamp dropped), no Python tracebacks under normal operation |
+| Unhandled promise rejection in worker | No — silently lost; `WindowLogSource` listens on `window`, not worker scope |
 | `logger.error(...)` (Python logging) | No — browser console only |
 
-This boundary is documented in ADR AD0009.
+This boundary is documented in ADR AD0009. The critical design decisions are:
 
-The critical design decision is that `ScriptWrapper` catches exceptions
-*before* they can propagate to the JS engine. If they reached the JS engine,
-`WorkerProcessingEngine.worker.onerror` would catch them and forward them to
-`LogForwarder`, which would send them to the host without any consent step.
-`ScriptWrapper` prevents this by intercepting the exception in Python and
-routing it through `error_flow` instead.
+1. **`ScriptWrapper`** catches exceptions in Python before they can propagate
+   to the JS engine. This is the primary defense and the only one with a
+   consent gate.
+2. **`runCycle()` try/catch** (Layer 2) prevents host forwarding if Layer 1
+   fails, but shows the traceback to the participant without consent.
+3. **`worker.onerror`** (Layer 3) is a narrow fallback — it only catches
+   synchronous errors from `firstRunCycle`. For `nextRunCycle` (the common
+   case), an exception escaping both Layer 1 and Layer 2 would be silently
+   lost. This is arguably a safer failure mode (no PII leak to the host), but
+   it means the error is invisible to everyone, including the researcher.
 
 ---
 
@@ -115,3 +254,7 @@ routing it through `error_flow` instead.
 | `packages/python/port/api/d3i_props.py` | `ExtractionResult.errors` Counter |
 | `packages/python/port/helpers/flow_builder.py` | Formats error counts for `emit_log` |
 | `packages/feldspar/src/framework/processing/worker_engine.ts` | `worker.onerror` — JS-side catch |
+
+---
+
+→ [Rendering and the factory system](08-rendering.md) — how commands become React components on screen

--- a/doc/source/architecture/07-error-handling.md
+++ b/doc/source/architecture/07-error-handling.md
@@ -1,0 +1,117 @@
+# Error Handling
+
+There are three categories of error in the system, each handled differently.
+The dividing lines are chosen to protect participant PII.
+
+---
+
+## Category 1: Expected extraction errors
+
+These are foreseeable failures during file parsing — a missing file in the
+zip, a malformed CSV, an unexpected encoding. They are caught inside
+`extract_data()`, counted by exception type, and reported as a summary after
+extraction completes.
+
+**How it works:**
+
+1. `ZipArchiveReader` catches parsing exceptions internally and increments
+   `errors[ExceptionType.__name__]` in the shared `Counter`
+2. `extract_data()` returns `ExtractionResult(tables=..., errors=errors)`
+3. `FlowBuilder.start_flow()` reads `result.errors` and formats the counts:
+   `"errors: FileNotFoundInZipError×2, KeyError×1"`
+4. This string is forwarded via `ph.emit_log()` → Path A → host
+
+**What the host sees:** Exception type names and counts. No messages, no
+tracebacks, no file contents.
+
+**Where errors accumulate:** `packages/python/port/helpers/extraction_helpers.py`
+(`ZipArchiveReader`) and in per-file functions in each platform module.
+
+---
+
+## Category 2: Uncaught Python exceptions
+
+If an exception escapes `extract_data()` — or any other part of the script
+generator — `ScriptWrapper.send()` catches it before it can propagate into
+the JS engine.
+
+```mermaid
+flowchart TD
+    A["ScriptWrapper.send()\nmain.py"]
+    B{"Exception\nescaped?"}
+    C["traceback.format_exc()\ncaptured in Python only\nnever forwarded automatically"]
+    D["self._error_handler =\nerror_flow(platform, tb)"]
+    E["yield CommandUIRender\nconsent page shown to participant\n'Would you like to report this error?'"]
+    F{"Participant\nconsents?"}
+    G["yield CommandSystemDonate\nkey='error-report'\nvalue: platform + traceback + timestamp"]
+    H["Sent via bridge\nreaches host as a donation payload"]
+    I["CommandSystemExit(0)\nscript ends silently"]
+
+    A --> B
+    B -- yes --> C --> D --> E --> F
+    F -- PayloadTrue --> G --> H
+    F -- "PayloadFalse / skip" --> I
+    B -- no --> Z["Normal command\nreturned to JS"]
+```
+
+**Key behaviours:**
+
+- The traceback is shown to the participant on screen, so they can see what
+  went wrong. It is not forwarded to the host without their explicit consent.
+- If the participant consents, the traceback is donated as structured JSON to
+  the key `"error-report"`.
+- If the participant declines, the script ends silently — no error is recorded
+  anywhere the host can see.
+- Once `self._error_handler` is set, all subsequent `send()` calls are routed
+  through `error_flow` until it completes.
+
+**What the host sees:** Either nothing, or a full donation payload containing
+the traceback — but only with consent.
+
+---
+
+## Category 3: JavaScript-side errors
+
+Errors originating in JavaScript (worker crashes, unhandled promise
+rejections, `window.onerror` events) never touch Python or `error_flow`.
+They go through [Path B of the logging system](06-logging.md#path-b-js-logforwarder)
+directly to the host.
+
+**What the host sees:** Error level log entries with message and context
+(memory usage, filename, line number). No participant data.
+
+---
+
+## PII safety boundary
+
+The architecture is designed so that raw exception text — which may contain
+participant data (file paths, field values, etc.) — is never forwarded to the
+host without consent.
+
+| Path | Raw exception text reaches host? |
+|---|---|
+| `emit_log` (Path A) | No — counts and type names only |
+| `LogForwarder` (Path B) | No — JS errors only, no Python tracebacks |
+| `error_flow` donation | Only with explicit participant consent |
+| `logger.error(...)` (Python logging) | No — browser console only |
+
+This boundary is documented in ADR AD0009.
+
+The critical design decision is that `ScriptWrapper` catches exceptions
+*before* they can propagate to the JS engine. If they reached the JS engine,
+`WorkerProcessingEngine.worker.onerror` would catch them and forward them to
+`LogForwarder`, which would send them to the host without any consent step.
+`ScriptWrapper` prevents this by intercepting the exception in Python and
+routing it through `error_flow` instead.
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `packages/python/port/main.py` | `ScriptWrapper`, `error_flow()` |
+| `packages/python/port/helpers/extraction_helpers.py` | `ZipArchiveReader` — catches extraction errors |
+| `packages/python/port/api/d3i_props.py` | `ExtractionResult.errors` Counter |
+| `packages/python/port/helpers/flow_builder.py` | Formats error counts for `emit_log` |
+| `packages/feldspar/src/framework/processing/worker_engine.ts` | `worker.onerror` — JS-side catch |

--- a/doc/source/architecture/08-rendering.md
+++ b/doc/source/architecture/08-rendering.md
@@ -1,0 +1,334 @@
+# Rendering and the Factory System
+
+When Python yields a `CommandUIRender`, the JS framework must turn it into a
+React component on screen. This is handled by a two-level factory system:
+**page factories** decide which page layout to use, and **prompt factories**
+decide how to render each item in the page's body.
+
+---
+
+## The two packages
+
+| Package | Role | Depends on |
+|---|---|---|
+| `feldspar` | Framework — run cycle, bridge, command routing, logging, base UI components | Nothing (library) |
+| `data-collector` | Application — composition root, custom UI components, worker entry point, Python wheel | `feldspar` |
+
+`data-collector` is the Vite app that gets built and served. `feldspar` is a
+library it consumes via `@eyra/feldspar` (workspace dependency). The split
+matters because feldspar provides the engine, while data-collector provides the
+D3I-specific experience.
+
+`data-collector/src/App.tsx` is the composition root:
+
+```tsx
+<ScriptHostComponent
+  workerUrl="./py_worker.js"
+  standalone={import.meta.env.DEV}
+  logLevel={import.meta.env.DEV ? "debug" : "info"}
+  factories={[
+    new DataSubmissionPageFactory({
+      promptFactories: [
+        new ConsentFormVizFactory(),
+        new FileInputMultipleFactory(),
+        new ErrorPageFactory(),
+        new QuestionnaireFactory(),
+        new RetryPromptFactory(),
+      ],
+    }),
+  ]}
+/>
+```
+
+The `standalone` flag determines `LiveBridge` (production, inside Eyra iframe)
+vs `FakeBridge` (dev, console + HTTP POST). The `factories` array is where
+data-collector plugs its custom components into feldspar's rendering pipeline.
+
+---
+
+## How a CommandUIRender becomes a React component
+
+```mermaid
+flowchart TD
+    CMD["CommandUIRender<br/>{page: {__type__, header, body[]}}"]
+    CR["CommandRouter.onCommand()"]
+    RE["ReactEngine.render(page)"]
+    RF["ReactFactory.createPage(page, context)"]
+    PF{{"iterate PageFactory[]<br/>first match wins"}}
+    DSP["DataSubmissionPageFactory<br/>matches PropsUIPageDataSubmission"]
+    EP["EndPageFactory<br/>matches PropsUIPageEnd"]
+    BODY["DataSubmissionPage<br/>iterates body[] items"]
+    PROMPT{{"iterate PromptFactory[]<br/>first match wins"}}
+    COMPONENT["Matched React component<br/>rendered on screen"]
+
+    CMD --> CR --> RE --> RF --> PF
+    PF --> DSP
+    PF --> EP
+    DSP --> BODY --> PROMPT --> COMPONENT
+```
+
+### Level 1: Page factories
+
+`ReactFactory` holds a list of `PageFactory` instances. When `createPage()` is
+called, it tries each factory in order. The first one whose `createPage()`
+returns non-null wins.
+
+feldspar always appends two defaults at the end of the list:
+
+- `DataSubmissionPageFactory` — matches `PropsUIPageDataSubmission`
+- `EndPageFactory` — matches `PropsUIPageEnd`
+
+data-collector passes its own `DataSubmissionPageFactory` (with custom prompt
+factories) as the first entry, so it takes priority over feldspar's default.
+
+**File:** `packages/feldspar/src/framework/visualization/react/factory.tsx`
+
+### Level 2: Prompt factories
+
+When `DataSubmissionPage` renders, it iterates the page's `body` array. Each
+body item has a `__type__` field. For each item, `DataSubmissionPage` tries
+every registered `PromptFactory` in order until one returns a JSX element.
+
+Custom factories (from data-collector) are prepended; feldspar's defaults are
+appended by `createPromptFactoriesWithDefaults()`:
+
+```
+Custom:   ConsentFormVizFactory, FileInputMultipleFactory, ErrorPageFactory,
+          QuestionnaireFactory, RetryPromptFactory
+Default:  FileInputFactory, ProgressFactory, ConfirmFactory, RadioInputFactory,
+          TableFactory, DonateButtonsFactory, TextBlockFactory
+```
+
+Each factory checks `body.__type__` and returns a component or `null`:
+
+```typescript
+class ErrorPageFactory implements PromptFactory {
+  create(body: unknown, context: ReactFactoryContext) {
+    if ((body as any).__type__ === "PropsUIPageError") {
+      return <ErrorPage {...body} {...context} />;
+    }
+    return null;
+  }
+}
+```
+
+**File:** `packages/feldspar/src/framework/visualization/react/ui/prompts/factory.ts`
+
+---
+
+## Prompt factory reference
+
+### feldspar built-in factories
+
+| Factory | Matches `__type__` | Component |
+|---|---|---|
+| `FileInputFactory` | `PropsUIPromptFileInput` | Single file picker |
+| `ProgressFactory` | `PropsUIPromptProgress` | Progress bar |
+| `ConfirmFactory` | `PropsUIPromptConfirm` | Confirm / cancel buttons |
+| `RadioInputFactory` | `PropsUIPromptRadioInput` | Radio button selection |
+| `TableFactory` | `PropsUIPromptConsentFormTable` | Read-only data table |
+| `DonateButtonsFactory` | `PropsUIDataSubmissionButtons` | Donate / cancel buttons |
+| `TextBlockFactory` | `PropsUIPromptText` | Static text block |
+
+### data-collector custom factories
+
+| Factory | Matches `__type__` | Component | Purpose |
+|---|---|---|---|
+| `ConsentFormVizFactory` | `PropsUIPromptConsentFormViz` | `ConsentFormViz` | Tables with search, row deletion, pagination, visualizations |
+| `FileInputMultipleFactory` | `PropsUIPromptFileInputMultiple` | `FileInputMultiple` | Multi-file upload |
+| `ErrorPageFactory` | `PropsUIPageError` | `ErrorPage` | Error display (including synthetic errors from `generateErrorMessage`) |
+| `QuestionnaireFactory` | `PropsUIPromptQuestionnaire` | `Questionnaire` | Open and multiple-choice questions |
+| `RetryPromptFactory` | `PropsUIPromptRetry` | `RetryPrompt` | Single-button retry (registered but **not used** by standard FlowBuilder — see note below) |
+
+**Note on retry:** The standard `FlowBuilder` retry prompt uses feldspar's
+`PropsUIPromptConfirm` (matched by the built-in `ConfirmFactory`), not
+`PropsUIPromptRetry`. This is because the retry flow needs both "Try again"
+and "Continue" buttons, while `RetryPrompt` only renders a single button.
+`RetryPromptFactory` is registered and available for custom flows but is not
+exercised by the standard path. See `port_helpers.generate_retry_prompt()`.
+
+---
+
+## The consent form data round-trip
+
+`ConsentFormViz` is the most complex UI component and the one participants
+interact with most. It handles the full cycle from extracted data to donated
+payload.
+
+```mermaid
+flowchart LR
+    EX["ExtractionResult.tables<br/>(Python DataFrames)"]
+    SER["Serialised to JSON<br/>via .toDict()"]
+    CMD["CommandUIRender<br/>body: PropsUIPromptConsentFormViz"]
+    CFV["ConsentFormViz<br/>parses JSON → tables"]
+    PART(("Participant<br/>reviews, searches,<br/>deletes rows"))
+    DON["handleDonate()<br/>serializeConsentData()"]
+    PJ["resolve(PayloadJSON)<br/>edited data as JSON string"]
+    PY["Python receives<br/>yield return value"]
+
+    EX --> SER --> CMD --> CFV --> PART --> DON --> PJ --> PY
+```
+
+**What the participant can do:**
+
+- **Search** within tables (via `SearchBar`)
+- **Delete rows** they don't want to share (via checkboxes)
+- **Paginate** through large tables
+- **View visualizations** (word clouds, charts) if the table defines them
+
+**What gets donated:**
+
+When the participant clicks "Yes, share for research", `serializeConsentData()`
+walks the (possibly modified) tables and produces a JSON string. This includes
+the remaining rows and a `"deleted row count"` per table. The result is sent
+back to Python as `PayloadJSON`, where `FlowBuilder.start_flow()` passes it
+to `ph.donate()` → `CommandSystemDonate` → bridge → host.
+
+The key point: **the data that reaches the host may differ from what was
+extracted**, because the participant can delete rows before consenting.
+
+**File:** `packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx`
+
+---
+
+## The resolve callback
+
+Every page component receives a `resolve` function via `ReactFactoryContext`.
+This is the mechanism that returns the participant's response back to the run
+cycle:
+
+1. `ReactEngine.renderPage()` creates a `Promise` and passes its `resolve`
+   to the page component via context
+2. The component calls `resolve(payload)` when the participant acts — e.g.
+   `resolve({ __type__: "PayloadJSON", value: jsonString })`
+3. The promise resolves, `ReactEngine.render()` returns the `Response`
+4. `CommandRouter` returns the response to `WorkerProcessingEngine`
+5. WPE sends `nextRunCycle` to the worker, which calls `pyScript.send(payload)`
+6. Python's `yield` receives the payload
+
+This is how the co-routine loop described in [02-run-cycle](02-run-cycle.md)
+connects to visible UI: `resolve` is the bridge from React back into the
+run cycle.
+
+**File:** `packages/feldspar/src/framework/visualization/react/engine.tsx`
+
+---
+
+## Iframe lifecycle
+
+`ScriptHostComponent` manages two communication channels with the parent
+window that are separate from the `MessageChannel` bridge:
+
+### 1. `app-loaded` signal
+
+On mount, `ScriptHostComponent` posts `{action: "app-loaded"}` to
+`window.parent`. Eyra mono listens for this and responds with `live-init`,
+which carries the `MessagePort` used to create `LiveBridge`. This is the
+handshake that establishes the bridge.
+
+### 2. Resize observer
+
+A `ResizeObserver` watches `document.body` and posts `{action: "resize", height}`
+to `window.parent` whenever the content height changes. Mono uses this to
+adjust the iframe height so there are no scrollbars inside the iframe.
+
+### Lifecycle sequence
+
+```mermaid
+sequenceDiagram
+    participant DC as data-collector<br/>(iframe)
+    participant MONO as Eyra mono<br/>(parent)
+
+    DC->>MONO: postMessage {action: "app-loaded"}
+    MONO->>DC: postMessage {action: "live-init", port, locale}
+    DC->>DC: LiveBridge.create(port)
+    DC->>DC: Assembly wires all components
+    DC->>DC: processingEngine.start()
+
+    loop On content resize
+        DC->>MONO: postMessage {action: "resize", height}
+    end
+
+    note over DC,MONO: All subsequent communication<br/>goes through the MessagePort<br/>(bridge.send / bridge.sendLogs)
+```
+
+**File:** `packages/feldspar/src/components/script_host_component.tsx`
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `packages/data-collector/src/App.tsx` | Composition root — registers factories, configures ScriptHostComponent |
+| `packages/data-collector/src/index.tsx` | React entry point |
+| `packages/data-collector/public/py_worker.js` | Worker entry point (hosted by data-collector, not feldspar) |
+| `packages/data-collector/public/port-0.0.0-py3-none-any.whl` | Python wheel installed in Pyodide at startup (see below) |
+| `packages/feldspar/src/components/script_host_component.tsx` | `ScriptHostComponent` — bridge creation, iframe lifecycle |
+| `packages/feldspar/src/framework/assembly.ts` | Wires ReactFactory, ReactEngine, CommandRouter, LogForwarder, WorkerProcessingEngine |
+| `packages/feldspar/src/framework/visualization/react/factory.tsx` | `ReactFactory` — page factory dispatch |
+| `packages/feldspar/src/framework/visualization/react/engine.tsx` | `ReactEngine` — renders pages, manages resolve callbacks |
+| `packages/feldspar/src/framework/visualization/react/ui/prompts/factory.ts` | Built-in prompt factories, `createPromptFactoriesWithDefaults()` |
+| `packages/feldspar/src/framework/visualization/react/factories/data_submission_page.tsx` | `DataSubmissionPageFactory` |
+| `packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx` | `ConsentFormViz` — table rendering, row deletion, donate serialization |
+
+---
+
+## The Python wheel
+
+The entire `packages/python/port` package — FlowBuilder, extraction helpers,
+platform modules, commands, everything — is shipped to the browser as a single
+Python wheel: `port-0.0.0-py3-none-any.whl`.
+
+### How it's built
+
+The root `package.json` defines two build steps:
+
+```
+build:wheel        →  cd packages/python && poetry build --format wheel
+build:install-wheel →  copyfiles -f packages/python/dist/*.whl packages/data-collector/public
+```
+
+`pnpm run build:py` runs both in sequence. Poetry reads
+`packages/python/pyproject.toml` (name: `port`, version: `0.0.0`), produces
+`dist/port-0.0.0-py3-none-any.whl`, and the second step copies it into
+data-collector's `public/` directory where Vite serves it as a static asset.
+
+### How it's loaded
+
+During worker initialisation, `py_worker.js` runs:
+
+```javascript
+await micropip.install("./port-0.0.0-py3-none-any.whl", deps=False)
+```
+
+`micropip` fetches the wheel from the same origin (it's a relative URL to
+data-collector's public directory), unpacks it into Pyodide's virtual
+filesystem, and makes `import port` available. `deps=False` skips dependency
+resolution — pandas and numpy are pre-loaded by `pyodide.loadPackage()` in
+the previous step.
+
+### What's in the repo vs what's built
+
+| File | In git? | Notes |
+|---|---|---|
+| `packages/python/port/` | Yes | Source code — the actual Python package |
+| `packages/python/pyproject.toml` | Yes | Poetry project definition (name, version, deps) |
+| `packages/python/dist/*.whl` | No | Build artifact, gitignored |
+| `packages/data-collector/public/port-0.0.0-py3-none-any.whl` | No | Copied from dist, gitignored |
+| `packages/data-collector/public/port-0.0.0.tar.gz` | Yes | Legacy committed sdist — not used by `py_worker.js` (which loads the `.whl`) |
+
+The version is hardcoded at `0.0.0` because it is never published to PyPI —
+it only needs to be loadable by micropip inside the worker.
+
+### Dev workflow
+
+During development, `pnpm start` runs `nodemon --ext py --exec "pnpm run build:py"`,
+which watches for `.py` file changes and rebuilds + copies the wheel
+automatically. A browser refresh then picks up the new wheel.
+
+**Key files:** `packages/python/pyproject.toml`, `package.json` (root, build scripts), `packages/data-collector/public/py_worker.js` (install step)
+
+---
+
+→ Back to [overview](01-overview.md) — the full system in context

--- a/doc/source/architecture/index.md
+++ b/doc/source/architecture/index.md
@@ -1,0 +1,33 @@
+# Architecture
+
+How the data donation task is built and how its parts work together.
+
+---
+
+## Reading order
+
+If you're new to the codebase, read these in order:
+
+1. [System overview](01-overview.md) — what it is, how it fits with Eyra mono
+2. [The run cycle](02-run-cycle.md) — the Python↔JS co-routine that drives everything
+3. [Command protocol](03-command-protocol.md) — the four command types and their responses
+4. [FlowBuilder](04-flowbuilder.md) — the per-platform flow lifecycle
+5. [Extraction](05-extraction.md) — zip reading, validation, ExtractionResult
+6. [Logging](06-logging.md) — two paths to the host, PII rules
+7. [Error handling](07-error-handling.md) — ScriptWrapper, error_flow, the PII boundary
+
+---
+
+## Quick answers
+
+| Question | Document |
+|---|---|
+| What is data-donation-task and how does it talk to Eyra? | [Overview](01-overview.md) |
+| How does Python run in a browser? | [Run cycle](02-run-cycle.md) |
+| What is a Command? What types exist? | [Command protocol](03-command-protocol.md) |
+| What does FlowBuilder do? How do I extend it? | [FlowBuilder](04-flowbuilder.md) |
+| How does extraction work? | [Extraction](05-extraction.md) |
+| How do log messages reach the host? | [Logging](06-logging.md) |
+| What happens when Python throws an exception? | [Error handling](07-error-handling.md) |
+| Where is the PII safety boundary? | [Error handling § PII safety](07-error-handling.md#pii-safety-boundary) |
+| What is the difference between LiveBridge and FakeBridge? | [Overview § The bridge](01-overview.md#the-bridge) |

--- a/doc/source/architecture/index.md
+++ b/doc/source/architecture/index.md
@@ -15,6 +15,7 @@ If you're new to the codebase, read these in order:
 5. [Extraction](05-extraction.md) — zip reading, validation, ExtractionResult
 6. [Logging](06-logging.md) — two paths to the host, PII rules
 7. [Error handling](07-error-handling.md) — ScriptWrapper, error_flow, the PII boundary
+8. [Rendering](08-rendering.md) — how commands become React components, the factory system, consent form round-trip
 
 ---
 
@@ -31,3 +32,8 @@ If you're new to the codebase, read these in order:
 | What happens when Python throws an exception? | [Error handling](07-error-handling.md) |
 | Where is the PII safety boundary? | [Error handling § PII safety](07-error-handling.md#pii-safety-boundary) |
 | What is the difference between LiveBridge and FakeBridge? | [Overview § The bridge](01-overview.md#the-bridge) |
+| How do Python commands turn into React UI? | [Rendering](08-rendering.md) |
+| What is the factory system? How do I add a custom component? | [Rendering § Prompt factories](08-rendering.md#prompt-factory-reference) |
+| What is data-collector vs feldspar? | [Rendering § The two packages](08-rendering.md#the-two-packages) |
+| Can the participant edit data before donating? | [Rendering § Consent form round-trip](08-rendering.md#the-consent-form-data-round-trip) |
+| How does the iframe communicate with Eyra mono? | [Rendering § Iframe lifecycle](08-rendering.md#iframe-lifecycle) |

--- a/doc/source/architecture/index.rst
+++ b/doc/source/architecture/index.rst
@@ -12,3 +12,4 @@ Architecture
    05-extraction
    06-logging
    07-error-handling
+   08-rendering

--- a/doc/source/architecture/index.rst
+++ b/doc/source/architecture/index.rst
@@ -1,0 +1,14 @@
+Architecture
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   index
+   01-overview
+   02-run-cycle
+   03-command-protocol
+   04-flowbuilder
+   05-extraction
+   06-logging
+   07-error-handling

--- a/doc/source/getting_started/creating-your-own-data-donation-task.md
+++ b/doc/source/getting_started/creating-your-own-data-donation-task.md
@@ -1,59 +1,136 @@
 # Creating your own data donation task
 
+After you have forked or cloned and installed the repository you can start creating your own donation task.
 
-After you have forked or cloned and installed the repository you can start creating your own donation task. 
+The extraction code lives in `packages/python/port`. The key pieces are:
 
-You can create your own study by changing and/or adapting the code in the following directory `packages/python/port`
-This directory contains the following files:
+* `script.py` — orchestrator that sequences platforms and delegates to FlowBuilder
+* `platforms/` — one module per platform, each containing a FlowBuilder subclass
+* `helpers/flow_builder.py` — the shared donation flow (file prompt → validate → extract → consent → donate)
+* `helpers/validate.py` — DDP validation using `DDP_CATEGORIES`
+* `helpers/extraction_helpers.py` — `ZipArchiveReader` and data parsing utilities
 
-* `d3i_example_script.py`: Contains your donation task logic; which screen the participants will see and in what order
-* `api/commands.py`: Contains the render and the donate commands
+## How FlowBuilder works
 
-## `d3i_example_script.py`
+Each platform implements a **FlowBuilder subclass** with two methods:
 
-Lets look at the example script in [`d3i_example_script.py`](https://github.com/d3i-infra/data-donation-task/blob/master/packages/python/port/d3i_example_script.py). 
+* `validate_file(file)` — check whether the uploaded zip is a valid DDP for this platform
+* `extract_data(file_value, validation)` — extract tables from the zip and return an `ExtractionResult`
 
-`d3i_example_script.py` must contain a function called `process` this function determines the whole data donation task from start to finish (Which screens the participant will see and in what order, and what kind of data extraction will take place). 
+FlowBuilder handles everything else: prompting the participant for a file, retry on invalid uploads, safety checks, rendering consent tables, and submitting the donation.
 
-In this example process defines the following data donation task:
+Here is a minimal example (based on [LinkedIn](https://github.com/d3i-infra/data-donation-task/blob/master/packages/python/port/platforms/linkedin.py)):
 
-1. Ask the participant to submit a zip file
-2. Perform validation on the submitted zip file, if not valid return to step 1
-3. Extract the data from the submitted zip file
-4. Render the extract data on screen in a table
-5. Send the data to the data storage upon consent
+```python
+# platforms/my_platform.py
+from collections import Counter
+import pandas as pd
 
-Although these can vary per data donation task, they will be mostly similar.
+import port.api.props as props
+import port.api.d3i_props as d3i_props
+from port.api.d3i_props import ExtractionResult
+from port.helpers.extraction_helpers import ZipArchiveReader
+from port.helpers.flow_builder import FlowBuilder
+import port.helpers.validate as validate
+from port.helpers.validate import DDPCategory, DDPFiletype, Language
 
-The `d3i_example_script.py` is annotated, read it carefully and see whether you can follow the logic.
+DDP_CATEGORIES = [
+    DDPCategory(
+        id="json_en",
+        ddp_filetype=DDPFiletype.JSON,
+        language=Language.EN,
+        known_files=["data.json", "profile.json"]
+    )
+]
+
+def extraction(zip_path: str, validation) -> ExtractionResult:
+    errors = Counter()
+    reader = ZipArchiveReader(zip_path, validation.archive_members, errors)
+
+    result = reader.json("data.json")
+    if result.found:
+        df = pd.DataFrame(result.data)
+    else:
+        df = pd.DataFrame()
+
+    tables = [
+        d3i_props.PropsUIPromptConsentFormTableViz(
+            id="my_table",
+            data_frame=df,
+            title=props.Translatable({"en": "My Data", "nl": "Mijn gegevens"}),
+        )
+    ]
+    return ExtractionResult(tables=tables, errors=errors)
 
 
-## Start writing your own `d3i_example_script.py` using the api
+class MyPlatformFlow(FlowBuilder):
+    def __init__(self, session_id: str):
+        super().__init__(session_id, "MyPlatform")
 
-Now that you have seen a full example, you can start to try and create your own data donation task. With the elements from the example you can already build some pretty intricate data donation tasks.
-Start creating your own by `d3i_example_script.py` by adapting this example to your own needs, for example, instead of file names you could extract data you would actually like to extract yourself.
+    def validate_file(self, file):
+        return validate.validate_zip(DDP_CATEGORIES, file)
 
-If you want to see which up what UI elements are available to you checkout `api/props.py` or `api/d3i_props.py`.
+    def extract_data(self, file_value, validation):
+        return extraction(file_value, validation)
 
-## The usage of `yield` in `d3i_example_script.py`
 
-`yield` makes sure that whenever the code resumes after a page render, it starts where it left off.
-If you render a page you need to use yield instead of return, just like in the example.
+def process(session_id):
+    flow = MyPlatformFlow(session_id)
+    return flow.start_flow()
+```
+
+## Registering your platform in script.py
+
+`script.py` maintains a registry of platforms. Add your platform:
+
+```python
+PLATFORM_REGISTRY = [
+    ("MyPlatform", "port.platforms.my_platform", "MyPlatformFlow"),
+    # ... other platforms
+]
+```
+
+Platforms are imported lazily, so only the platform(s) needed for a given build are loaded.
+
+## DDP_CATEGORIES
+
+Each platform defines which DDP formats it supports. `validate.validate_zip()` checks the uploaded file against these categories by comparing the zip's file list against the `known_files` for each category.
+
+```python
+DDP_CATEGORIES = [
+    DDPCategory(
+        id="json_en",
+        ddp_filetype=DDPFiletype.JSON,
+        language=Language.EN,
+        known_files=["conversations.json", "user.json"]
+    ),
+    DDPCategory(
+        id="csv_en",
+        ddp_filetype=DDPFiletype.CSV,
+        language=Language.EN,
+        known_files=["data.csv", "profile.csv"]
+    ),
+]
+```
+
+If your participants use a DDP format not covered by the existing categories, add a new `DDPCategory` entry with the expected files.
+
+## The usage of `yield`
+
+`yield` makes sure that whenever the code resumes after a page render, it starts where it left off. FlowBuilder uses `yield` internally — your extraction code does not need to yield unless you want to show progress messages during extraction.
+
+The `script.py` orchestrator uses `yield from flow.start_flow()` to delegate the full flow to FlowBuilder.
 
 ## Install Python packages
 
-The data donation task runs in the browser of the participant, it is important to understand that when Python is running in your browser it is not using the Python version you have installed on your system.
-The data donation task is using [Pyodide](https://pyodide.org/en/stable/) this is Python compiled to web assembly that runs in the browser. 
-This means that packages you have available on your system install of Python, won't be available in the browser.
+The data donation task runs in the browser of the participant using [Pyodide](https://pyodide.org/en/stable/) — Python compiled to WebAssembly. Packages available on your system install of Python won't automatically be available in the browser.
 
-If you want to use external packages they should be available for Pyodide, you can check the list of available packages [here](https://pyodide.org/en/stable/usage/packages-in-pyodide.html).
-If you have found a package you want to use you can installed it by adding it to the array in the `loadPackages` function in `src/framework/processing/py_worker.js` as shown below:
+If you want to use external packages they should be available for Pyodide. You can check the list of available packages [here](https://pyodide.org/en/stable/usage/packages-in-pyodide.html).
+If you have found a package you want to use, add it to the `loadPackages` function in `packages/data-collector/public/py_worker.js`:
 
 ```javascript
-// src/framework/processing/py_worker.js
 function loadPackages() {
   console.log('[ProcessingWorker] loading packages')
-  // These packages are now installed and usable: micropip, numpy, pandas, and lxml
   return self.pyodide.loadPackage(['micropip', 'numpy', 'pandas', 'lxml'])
 }
 ```
@@ -62,37 +139,26 @@ You can now import the packages as you would normally do in Python.
 
 ## Try the donation task from the perspective of the participant
 
-If you want to try out the above example, follow the installation instructions and start the server with `pnpm run start`.
+Follow the installation instructions and start the server with `pnpm start`. Visit `http://localhost:3000` to see the donation flow.
 
-## Tips when writing your own `d3i_example_script.py`
+## Tips
 
-**Split the extraction logic from the data donation task logic**
-You can define your own modules where you create your data extraction, you can `import` those modules in `d3i_example_script.py`
+**Use ZipArchiveReader for file access.**
+`reader.json()`, `reader.csv()`, and `reader.raw()` return found/not-found results instead of raising exceptions. This avoids error cascades when DDP files are missing (which is expected — DDPs vary by platform version and language).
 
-**Develop in separate script**
-You are better off engineering your extraction logic in different scripts and put them in `d3i_example_script.py` whenever you are finished developing. Only do small tweaks in `d3i_example_script.py`
+**Use the browser console for debugging.**
+`print()` and `logging.getLogger()` output appears in the browser console. These logs stay local and are not sent to the host platform.
 
-**Use the console in your browser**
-In case of errors they will show up in the browser console. You can use `print` in the Python script and it will show up in the browser console.
+**Keep the diverse nature of DDPs in mind.**
+Check a variety of DDPs to make sure your extraction handles: different data formats (HTML, JSON, CSV), language settings (which affect file names and JSON keys), and different download options (which affect which files are present).
 
-**Keep the diverse nature of DDPs into account**
-At least check a couple of DDPs to make sure its reflective of the population you are interesed in. Thinks you can check are: data formats (html, json, plain text, csv, etc.), language settings (they somethines lead to json keys being in a different language or file names other than English).
+**Don't let your code crash.**
+Uncaught exceptions stop the donation task. Use try/except in extraction functions and count errors via `errors[type(e).__name__] += 1` rather than letting them propagate.
 
-**Keep your code efficient**
-If your code is not efficient the extraction will take longer, which can result in a bad experience for the participant. In practice I have found that in most cases it's not really an issue, and don't have to pay that much attention to efficiency of your code.
-Where efficiency really matters is when you have parse huge html files, beautifulsoup4 is a library that is commonly used to do this, this library is too slow however. As an alternative you can use lxml which is fast enough.
+**Data donation checklist.**
+Check out the [wiki article](https://github.com/d3i-infra/data-donation-task/wiki/Data-donation-checklist) for a comprehensive checklist.
 
-**Don't let your code crash**
-You cannot have your script crash, if your Python script crashes the task stops as well. This is not a good experience for your participant.
-For example in the code you do the following: `value_i_want_to_extract = extracted_data_in_a_dictionary["interesting key"]` if the key `"interesting key"` does not exists, because it does not occur in the data of the participant, the script crashes and the participant cannot continue the data donation task.
+## Limits
 
-**Data donation checklist**
-Creating a good data donation task can be hard due to the variety of DDPs you will encounted. 
-Check out the following [wiki article](https://github.com/d3i-infra/data-donation-task/wiki/Data-donation-checklist)
-
-## Limits of the data donation task
-
-Currently the data donation task has the following limitations:
-
-* The data donation task is a frontend, you need to package this together with Next to deploy it. If you want to use it with your own backend you have to make the data donation task compatible with it yourself. A tutorial on how to do this might be added in the future.
-* The data donation task is running in the browser of the participant that brings in limitations, such as constraints on the files participant can submit. The limits are around 4 GiB thats what Pyodide can handle. But less is better. So keep that in mind whenever you, for example, want to collect data from YouTube: your participants should exclude their own personal videos from their DDP (including these would result in a huge number of separate DDPs of around 4 GiB).
+* The data donation task is a frontend — you need Next (or a compatible host) to deploy it.
+* Pyodide can handle files up to around 4 GiB, but less is better. For platforms like YouTube, participants should exclude personal videos from their DDP.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -92,6 +92,16 @@ Checkout the following articles to get started:
 
    getting_started/index
 
+Architecture
+============
+
+Internals and data-flow documentation:
+
+.. toctree::
+   :maxdepth: 2
+
+   architecture/index
+
 API Reference
 =============
 

--- a/doc/source/standard_scripts/index.rst
+++ b/doc/source/standard_scripts/index.rst
@@ -1,24 +1,17 @@
 Platform Documentation
 =============================
 
-For various platforms we provide default extraction scripts, so you do not have to reinvent the wheel.
+For various platforms we provide default extraction scripts built on the **FlowBuilder** pattern,
+so you do not have to reinvent the wheel.
 
-Feel free to use the extraction scripts however you see fit.
+Each platform module in ``packages/python/port/platforms/`` contains a ``FlowBuilder`` subclass
+that handles the full donation flow (file prompt, validation, extraction, consent, donation)
+and a ``process()`` function that ``script.py`` calls via ``yield from``.
 
-In order to use the scripts open the file ``packages/python/port/main.py`` and change this line:
+To run a single platform, you can either:
 
-.. code-block:: python
-
-    from port.script import process
-
-to:
-
-.. code-block:: python
-
-    #from port.script import process
-
-    # Change to (in this case the standard script for instagram will be used):
-    from port.platforms.instagram import process
+1. Set the ``VITE_PLATFORM`` environment variable to the platform name (used by per-platform release builds), or
+2. Edit the ``PLATFORM_REGISTRY`` list in ``script.py`` to include only the platform(s) you want
 
 Available platforms
 -------------------
@@ -26,6 +19,7 @@ Available platforms
 Currently we have default scripts for the following platforms:
 
 * ChatGPT
+* Chrome
 * Instagram
 * Facebook
 * LinkedIn


### PR DESCRIPTION
## Summary

Stacks on #[PR4-number] (`integration/upstream-sync`). **Base branch: `integration/upstream-sync`.**

Documentation updates for the v2.0.0 release. Covers the changelog, migration guide for downstream forks, README, and sphinx tutorial/API docs.

### Versioning change

This release switches from sequential numbering (#1-#5, matching eyra/feldspar) to **semantic versioning**. v2.0.0 incorporates eyra/feldspar #6 + #7 plus the d3i extraction consolidation work from PRs 1-4. The CHANGELOG cross-references eyra version numbers so downstream users tracking upstream can orient themselves.

## What changed

### CHANGELOG.md
- Replace `#6 UNRELEASED` with `v2.0.0 — 2026-03-23`
- Structured sections: Breaking, Added, Changed, Removed, Migration
- Restore d3i-infra's original #1-#5 history (PR 4's eyra merge had overwritten with eyra's entries)
- Add semver preamble explaining the numbering transition

### MIGRATION.md (new)
Guide for researchers with downstream forks. Covers:
- FlowBuilder migration (before/after code examples, based on tested LinkedIn platform)
- DDP_CATEGORIES and ZipArchiveReader
- PayloadFile (mostly transparent — ScriptWrapper auto-materializes)
- Logging boundaries (local loggers unchanged, host-visible requires CommandSystemLog)
- Donation key format change (`{session_id}` → `{session_id}-{platform}`)
- Testing commands

### README.md
- Remove self-referential "based on d3i data donation task" line
- Add "What's new in v2.0.0" section with links to CHANGELOG and MIGRATION.md
- Add link to sphinx documentation site

### Sphinx docs
- **Tutorial** (`creating-your-own-data-donation-task.md`): Full rewrite replacing `d3i_example_script.py` with FlowBuilder pattern. Complete working example, DDP_CATEGORIES explanation, ZipArchiveReader usage, updated tips.
- **Standard scripts** (`index.rst`): Add Chrome, describe FlowBuilder pattern, replace old `main.py` import instructions with `VITE_PLATFORM` and `PLATFORM_REGISTRY`.
- **API reference** (`api.md`): Add `flow_builder` and `uploads` modules to autodoc.

## Test plan
- [x] All documentation references checked against actual code in PR 3
- [x] Code examples in MIGRATION.md and tutorial based on tested platforms (LinkedIn)
- [ ] Sphinx build (`make html` in doc/) — should be verified before merge
