### PR TITLE
fix: stream PayloadFile uploads end-to-end (AD0007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,62 @@ This project follows [semantic versioning](https://semver.org/) starting from v2
 Earlier releases used sequential numbering (#1-#5) matching the upstream
 [eyra/feldspar](https://github.com/eyra/feldspar) convention.
 
+## [Unreleased]
+
+### Fixed
+
+* 2+ GiB upload `NotReadableError` regression. `FlowBuilder` no longer
+  materializes `PayloadFile` uploads to a path; the
+  `AsyncFileAdapter` is passed directly to `zipfile.ZipFile`,
+  validators, and extractors (extraction/AD0007). Restores the
+  streaming behavior of upstream eyra/feldspar PR
+  [#482](https://github.com/eyra/feldspar/pull/482), which the
+  FlowBuilder rewrite (`68c59d8`) silently reverted by adding a
+  full-file `adapter.read()` inside `materialize_file()`. The
+  resulting single-`ArrayBuffer` request triggered
+  `FileReaderSync.readAsArrayBuffer`'s ~2 GiB cap with
+  `NotReadableError`, often after a long apparent hang. Empirical
+  reproduction and full diagnosis:
+  [#61](https://github.com/d3i-infra/data-donation-task/issues/61).
+
+### Changed
+
+* Upload-path size validation now uses `adapter.size` (JS metadata,
+  no read) before any byte transfer, instead of `os.path.getsize`
+  on a materialized `/tmp` copy. The new helper is
+  `uploads.check_payload_size(file_result)`. The previous
+  `materialize_file()` and `check_file_safety(path)` are removed.
+* `ZipArchiveReader.__init__` and `validate.validate_zip` now accept
+  any seekable binary file-like (`IO[bytes]`) or a path string; the
+  upload pipeline passes an `AsyncFileAdapter` directly. Parameter
+  names (`zip_path`, `path_to_zip`) are retained for backwards
+  compatibility with researcher-fork callers and will be renamed in a
+  follow-up release.
+* `FlowBuilder.start_flow()` accepts only `PayloadFile` uploads.
+  `PayloadString`/WORKERFS support (kept for SURF Research Cloud
+  backwards compatibility per `feldspar/AD0003`) is retired; SRC
+  consumers must migrate to `PayloadFile`.
+* New host log milestone `[<Platform>] Upload prompt shown`
+  (emitted before the file prompt is rendered) and
+  `[<Platform>] Upload received: type=…, size=…` (emitted
+  immediately after upload, before safety check). Replaces the
+  previous post-materialize `[<Platform>] File received` message.
+
+### Removed
+
+* `materialize_file()` and `check_file_safety()` from
+  `port.helpers.uploads` — see Changed above for replacements.
+* The dual-payload-type branch (`PayloadFile` or `PayloadString`)
+  in `FlowBuilder` upload handling. Closes the deprecation window
+  opened by `feldspar/AD0003`.
+
+### Architectural Decisions
+
+* `extraction/AD0007` — Stream `PayloadFile` uploads end-to-end and
+  never materialize to a path. Succeeds `extraction/AD0003` (whose
+  ownership decision is preserved; only the size-check placement
+  changes).
+
 ## v2.0.0 — 2026-03-23
 
 Incorporates upstream eyra/feldspar #6 (2026-02-25) and #7 (2026-03-05), plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,14 @@ Earlier releases used sequential numbering (#1-#5) matching the upstream
   `PayloadString`/WORKERFS support (kept for SURF Research Cloud
   backwards compatibility per `feldspar/AD0003`) is retired; SRC
   consumers must migrate to `PayloadFile`.
-* New host log milestone `[<Platform>] Upload prompt shown`
-  (emitted before the file prompt is rendered) and
-  `[<Platform>] Upload received: type=…, size=…` (emitted
-  immediately after upload, before safety check). Replaces the
-  previous post-materialize `[<Platform>] File received` message.
+* New host log milestones: `[<Platform>] Upload prompt sent`
+  (emitted before the file prompt render command goes to the host),
+  `[<Platform>] Upload received: size=…` (emitted immediately after
+  a `PayloadFile` upload, before the safety check), and
+  `[<Platform>] Upload skipped: type=<X>` (emitted when a
+  non-`PayloadFile` payload arrives, distinguishing participant-skip
+  from unexpected payload types). Replaces the previous
+  post-materialize `[<Platform>] File received` message.
 
 ### Removed
 

--- a/docs/decisions/extraction/AD0003-reject-unsafe-uploads-before-ddp-validation-and-extraction.md
+++ b/docs/decisions/extraction/AD0003-reject-unsafe-uploads-before-ddp-validation-and-extraction.md
@@ -5,7 +5,8 @@ comments:
       comment: "1"
       date: "2026-03-17 13:23:34"
 links:
-    precedes: []
+    precedes:
+        - "0007"
     succeeds:
         - "0002"
 status: decided

--- a/docs/decisions/extraction/AD0007-stream-payloadfile-uploads-end-to-end-and-never-materialize-to-a-path.md
+++ b/docs/decisions/extraction/AD0007-stream-payloadfile-uploads-end-to-end-and-never-materialize-to-a-path.md
@@ -4,9 +4,6 @@ comments:
     - author: Danielle McCool
       comment: "1"
       date: "2026-04-30 19:11:46"
-    - author: Danielle McCool
-      comment: "2"
-      date: "2026-04-30 19:11:46"
 links:
     precedes: []
     succeeds:
@@ -22,45 +19,34 @@ title: Stream PayloadFile uploads end-to-end and never materialize to a path
 
 ## <a name="question"></a> Context and Problem Statement
 
-The FlowBuilder upload pipeline receives PayloadFile (an AsyncFileAdapter wrapping a browser File via FileReaderSync). The previous materialize_file() helper read the entire file into Python memory then wrote it to Pyodide's in-memory /tmp to produce a path string for downstream extractors. This calls FileReaderSync.readAsArrayBuffer() against the entire blob, which fails with NotReadableError for files above the DOM File API's ~2 GiB ArrayBuffer cap, independent of available RAM. SURF Research Cloud (SRC) no longer requires PayloadString/WORKERFS support, so the dual-payload plumbing introduced in feldspar/AD0003 can be retired. How should the upload pipeline handle PayloadFile to avoid this failure mode and stay aligned with upstream's streaming design?
+The previous `materialize_file()` helper called `AsyncFileAdapter.read()` with no size argument before handing a path to `zipfile.ZipFile`. That single `readAsArrayBuffer` call rejects with `NotReadableError` above the DOM File API's ~2 GiB ArrayBuffer cap — independent of available RAM. The bug was reproduced in production (#61). How should the upload pipeline avoid this?
 
 ## <a name="options"></a> Considered Options
-1. <a name="option-1"></a> Pass AsyncFileAdapter directly to zipfile.ZipFile and other consumers; delete materialize_file
-2. <a name="option-2"></a> Stream materialize_file in chunks to /tmp
-3. <a name="option-3"></a> Mount the browser Blob via WORKERFS and return a path string
+1. <a name="option-1"></a> Pass `AsyncFileAdapter` directly to consumers; delete `materialize_file`
+2. <a name="option-2"></a> Stream `materialize_file` in chunks to `/tmp`
 
 ## <a name="criteria"></a> Decision Drivers
-DOM File API caps readAsArrayBuffer at ~2 GiB; full-file reads fail above that limit regardless of available RAM
-Upstream eyra/feldspar PR #482 (2025-11-03) explicitly designed AsyncFileAdapter to avoid full-file reads — must preserve that intent
-Empirical reproduction on next.eyra.co with a 2.5 GiB Facebook fixture produced NotReadableError, confirming this code path is broken in production (see issue #61)
-SRC no longer needs PayloadString; dual-payload plumbing can collapse to a single payload type, shrinking the failure surface
-Multi-GiB takeouts (YouTube, Facebook) are routine; the upload path must not impose a ceiling lower than the documented safety check
+- DOM File API caps `readAsArrayBuffer` at ~2 GiB regardless of RAM.
+- Upstream eyra/feldspar PR #482 already designed `AsyncFileAdapter` to avoid full-file reads.
+- Multi-GiB takeouts (YouTube, Facebook) are routine; the read path must not impose a ceiling.
+
 ### Pros and Cons
 
-**Pass AsyncFileAdapter directly to zipfile.ZipFile and other consumers; delete materialize_file**
-* Good, because it is the upstream PR #482 design — proven and aligned with eyra/feldspar
-* Good, because AsyncFileAdapter already implements the file-like protocol zipfile.ZipFile requires (read, seek, tell, readable, seekable, context-manager)
-* Good, because zipfile chunks reads at its own discretion (≤ 1 MiB typical), well below the FileReaderSync cap
-* Good, because deleting materialize_file removes the failure surface entirely — no path-producing function exists for a future refactor to call
-* Good, because the size check (FileTooLargeError, ChunkedExportError) can move upstream to use adapter.size (JS metadata, no read), so it fires before any byte transfer
-* Neutral, because researcher forks still on the WORKERFS path must migrate before consuming this version
+**Pass `AsyncFileAdapter` directly; delete `materialize_file`**
+* Good, because `zipfile.ZipFile` already accepts any seekable file-like (`read`, `seek`, `tell`); `AsyncFileAdapter` qualifies.
+* Good, because `zipfile` chunks reads at its own discretion, well below the API cap.
+* Good, because deleting `materialize_file` removes the failure surface — no path-producing function for a future refactor to call.
 
-**Stream materialize_file in chunks to /tmp**
-* Good, because it avoids the FileReaderSync cap by reading slices ≤ chunk size
-* Bad, because /tmp is Pyodide's in-memory filesystem — the file is still copied into worker heap, defeating the memory benefit
-* Bad, because it preserves the materialize step as a permanent feature, leaving a path-producing function the next refactor can misuse
-* Bad, because it adds latency for no extraction benefit — zipfile would re-read /tmp lazily anyway
-
-**Mount the browser Blob via WORKERFS and return a path string**
-* Good, because consumers continue to receive a path string (no API change downstream)
-* Good, because reads happen lazily from the Blob via the filesystem layer
-* Bad, because it routes through a filesystem mechanism the codebase no longer needs (SRC compat dropped) — adds a layer instead of removing one
-* Bad, because it preserves PayloadString plumbing that feldspar/AD0003 marked as deprecated, blocking closure of that deprecation window
-
+**Stream `materialize_file` in chunks to `/tmp`**
+* Good, because it avoids the per-call cap.
+* Bad, because `/tmp` is Pyodide's in-memory filesystem — the file is still copied into the worker heap.
+* Bad, because it preserves `materialize_file` as a target for future regressions.
 
 ## <a name="outcome"></a> Decision Outcome
-We decided for [Option 1](#option-1) because: Option 1 restores the upstream PR #482 design. AsyncFileAdapter is already a complete file-like object; downstream consumers (zipfile.ZipFile, ZipArchiveReader, validate.validate_zip, parsers) accept it without modification because Python's zipfile takes any seekable binary file-like. Deleting materialize_file removes the failure surface — there is no path-producing function in the upload pipeline left to call. The size guard moves upstream to operate on adapter.size (a JS metadata attribute, no read required), so oversize files are rejected before any byte transfer rather than after a 2 GiB read attempt that the API will refuse. Defense in depth: type tightening on consumer signatures (str → seekable binary protocol) is enforced at the Pyright layer, and a behavioral regression test asserts that AsyncFileAdapter.read is never called with size=-1 from upload-path code. Consequences: the 2 GiB upload ceiling is removed for the read path; mono's HTTP body limit (200 MB default, env-overridable) remains a separate downstream concern for extracted JSON; researcher forks still on the WORKERFS path must migrate to PayloadFile before consuming this version, closing the deprecation window opened by feldspar/AD0003.
+
+Option 1. `AsyncFileAdapter` is passed directly to consumers; the size guard moves upstream to use `adapter.size` (JS metadata, no read). Closes the `PayloadString`/WORKERFS deprecation opened by feldspar/AD0003 — researcher forks still on the WORKERFS path must migrate to `PayloadFile` before consuming this version.
+
+**Enforcement.** The behavioral regression test in `tests/test_uploads.py::TestStreamingInvariant` asserts that `zipfile.ZipFile` against a tracking adapter never issues `read(-1)`, and runs in CI. The structural fact that `materialize_file()` no longer exists means a future regression has to deliberately add a new path-producing function — visible in code review. Pyright catches type violations locally and during review (`pnpm typecheck:py`), but is not currently a CI gate.
 
 ## <a name="comments"></a> Comments
-<a name="comment-2"></a>2. (2026-04-30 19:11:46) Danielle McCool: More Information:
-Succeeds extraction/AD0003 (which placed the size check after materialize, the buggy ordering this ADR corrects). The original AD0003 ownership decision (FlowBuilder owns upload safety, before validation/extraction) remains correct; only the placement of the size check changes. See feldspar/AD0003 for the PayloadFile migration whose intent this ADR enforces. Production reproduction and full diagnosis: https://github.com/d3i-infra/data-donation-task/issues/61. Upstream design: https://github.com/eyra/feldspar/pull/482.
+<a name="comment-1"></a>1. (2026-04-30 19:11:46) Danielle McCool: marked decision as decided

--- a/docs/decisions/extraction/AD0007-stream-payloadfile-uploads-end-to-end-and-never-materialize-to-a-path.md
+++ b/docs/decisions/extraction/AD0007-stream-payloadfile-uploads-end-to-end-and-never-materialize-to-a-path.md
@@ -1,0 +1,66 @@
+---
+adr_id: "0007"
+comments:
+    - author: Danielle McCool
+      comment: "1"
+      date: "2026-04-30 19:11:46"
+    - author: Danielle McCool
+      comment: "2"
+      date: "2026-04-30 19:11:46"
+links:
+    precedes: []
+    succeeds:
+        - "0003"
+status: decided
+tags:
+    - uploads
+    - streaming
+    - memory-safety
+    - file-api
+title: Stream PayloadFile uploads end-to-end and never materialize to a path
+---
+
+## <a name="question"></a> Context and Problem Statement
+
+The FlowBuilder upload pipeline receives PayloadFile (an AsyncFileAdapter wrapping a browser File via FileReaderSync). The previous materialize_file() helper read the entire file into Python memory then wrote it to Pyodide's in-memory /tmp to produce a path string for downstream extractors. This calls FileReaderSync.readAsArrayBuffer() against the entire blob, which fails with NotReadableError for files above the DOM File API's ~2 GiB ArrayBuffer cap, independent of available RAM. SURF Research Cloud (SRC) no longer requires PayloadString/WORKERFS support, so the dual-payload plumbing introduced in feldspar/AD0003 can be retired. How should the upload pipeline handle PayloadFile to avoid this failure mode and stay aligned with upstream's streaming design?
+
+## <a name="options"></a> Considered Options
+1. <a name="option-1"></a> Pass AsyncFileAdapter directly to zipfile.ZipFile and other consumers; delete materialize_file
+2. <a name="option-2"></a> Stream materialize_file in chunks to /tmp
+3. <a name="option-3"></a> Mount the browser Blob via WORKERFS and return a path string
+
+## <a name="criteria"></a> Decision Drivers
+DOM File API caps readAsArrayBuffer at ~2 GiB; full-file reads fail above that limit regardless of available RAM
+Upstream eyra/feldspar PR #482 (2025-11-03) explicitly designed AsyncFileAdapter to avoid full-file reads — must preserve that intent
+Empirical reproduction on next.eyra.co with a 2.5 GiB Facebook fixture produced NotReadableError, confirming this code path is broken in production (see issue #61)
+SRC no longer needs PayloadString; dual-payload plumbing can collapse to a single payload type, shrinking the failure surface
+Multi-GiB takeouts (YouTube, Facebook) are routine; the upload path must not impose a ceiling lower than the documented safety check
+### Pros and Cons
+
+**Pass AsyncFileAdapter directly to zipfile.ZipFile and other consumers; delete materialize_file**
+* Good, because it is the upstream PR #482 design — proven and aligned with eyra/feldspar
+* Good, because AsyncFileAdapter already implements the file-like protocol zipfile.ZipFile requires (read, seek, tell, readable, seekable, context-manager)
+* Good, because zipfile chunks reads at its own discretion (≤ 1 MiB typical), well below the FileReaderSync cap
+* Good, because deleting materialize_file removes the failure surface entirely — no path-producing function exists for a future refactor to call
+* Good, because the size check (FileTooLargeError, ChunkedExportError) can move upstream to use adapter.size (JS metadata, no read), so it fires before any byte transfer
+* Neutral, because researcher forks still on the WORKERFS path must migrate before consuming this version
+
+**Stream materialize_file in chunks to /tmp**
+* Good, because it avoids the FileReaderSync cap by reading slices ≤ chunk size
+* Bad, because /tmp is Pyodide's in-memory filesystem — the file is still copied into worker heap, defeating the memory benefit
+* Bad, because it preserves the materialize step as a permanent feature, leaving a path-producing function the next refactor can misuse
+* Bad, because it adds latency for no extraction benefit — zipfile would re-read /tmp lazily anyway
+
+**Mount the browser Blob via WORKERFS and return a path string**
+* Good, because consumers continue to receive a path string (no API change downstream)
+* Good, because reads happen lazily from the Blob via the filesystem layer
+* Bad, because it routes through a filesystem mechanism the codebase no longer needs (SRC compat dropped) — adds a layer instead of removing one
+* Bad, because it preserves PayloadString plumbing that feldspar/AD0003 marked as deprecated, blocking closure of that deprecation window
+
+
+## <a name="outcome"></a> Decision Outcome
+We decided for [Option 1](#option-1) because: Option 1 restores the upstream PR #482 design. AsyncFileAdapter is already a complete file-like object; downstream consumers (zipfile.ZipFile, ZipArchiveReader, validate.validate_zip, parsers) accept it without modification because Python's zipfile takes any seekable binary file-like. Deleting materialize_file removes the failure surface — there is no path-producing function in the upload pipeline left to call. The size guard moves upstream to operate on adapter.size (a JS metadata attribute, no read required), so oversize files are rejected before any byte transfer rather than after a 2 GiB read attempt that the API will refuse. Defense in depth: type tightening on consumer signatures (str → seekable binary protocol) is enforced at the Pyright layer, and a behavioral regression test asserts that AsyncFileAdapter.read is never called with size=-1 from upload-path code. Consequences: the 2 GiB upload ceiling is removed for the read path; mono's HTTP body limit (200 MB default, env-overridable) remains a separate downstream concern for extracted JSON; researcher forks still on the WORKERFS path must migrate to PayloadFile before consuming this version, closing the deprecation window opened by feldspar/AD0003.
+
+## <a name="comments"></a> Comments
+<a name="comment-2"></a>2. (2026-04-30 19:11:46) Danielle McCool: More Information:
+Succeeds extraction/AD0003 (which placed the size check after materialize, the buggy ordering this ADR corrects). The original AD0003 ownership decision (FlowBuilder owns upload safety, before validation/extraction) remains correct; only the placement of the size check changes. See feldspar/AD0003 for the PayloadFile migration whose intent this ADR enforces. Production reproduction and full diagnosis: https://github.com/d3i-infra/data-donation-task/issues/61. Upstream design: https://github.com/eyra/feldspar/pull/482.

--- a/docs/decisions/extraction/index.yaml
+++ b/docs/decisions/extraction/index.yaml
@@ -41,7 +41,8 @@ decisions:
             - uploads
             - flowbuilder
         links:
-            precedes: []
+            precedes:
+                - "0007"
             succeeds:
                 - "0002"
         comments:
@@ -108,3 +109,23 @@ decisions:
             - author: Danielle McCool
               date: "2026-03-21 15:24:08"
               comment: "4"
+    "0007":
+        adr_id: "0007"
+        title: Stream PayloadFile uploads end-to-end and never materialize to a path
+        status: decided
+        tags:
+            - uploads
+            - streaming
+            - memory-safety
+            - file-api
+        links:
+            precedes: []
+            succeeds:
+                - "0003"
+        comments:
+            - author: Danielle McCool
+              date: "2026-04-30 19:11:46"
+              comment: "1"
+            - author: Danielle McCool
+              date: "2026-04-30 19:11:46"
+              comment: "2"

--- a/docs/decisions/extraction/index.yaml
+++ b/docs/decisions/extraction/index.yaml
@@ -126,6 +126,3 @@ decisions:
             - author: Danielle McCool
               date: "2026-04-30 19:11:46"
               comment: "1"
-            - author: Danielle McCool
-              date: "2026-04-30 19:11:46"
-              comment: "2"

--- a/packages/python/port/api/file_utils.py
+++ b/packages/python/port/api/file_utils.py
@@ -38,6 +38,16 @@ class AsyncFileAdapter:
 
         Returns:
             bytes: The data read from the file.
+
+        Note:
+            Upload-pipeline code must NEVER call this with size=-1 (or no
+            argument). A full-file read issues a single
+            FileReaderSync.readAsArrayBuffer() call against the entire
+            blob, which fails with NotReadableError above the DOM File
+            API's ~2 GiB ArrayBuffer cap regardless of available RAM.
+            Pass this adapter directly to zipfile.ZipFile (which chunks
+            reads at its own discretion) or call read(size=N) with a
+            bounded N. See extraction/AD0007.
         """
         if self._closed:
             raise ValueError("I/O operation on closed file")

--- a/packages/python/port/helpers/extraction_helpers.py
+++ b/packages/python/port/helpers/extraction_helpers.py
@@ -7,7 +7,7 @@ import logging
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import IO, Any, Callable, Union
 from pathlib import Path
 import zipfile
 import csv
@@ -597,10 +597,17 @@ class RawExtractionResult:
 class ZipArchiveReader:
     """Reads files from a zip archive using cached member inventory.
 
-    Encapsulates the zip path, archive member list (from validation),
-    and error counter. Provides json()/csv()/raw() methods with
-    found/not-found signaling to eliminate cascading errors for
+    Encapsulates the zip path or file-like, archive member list (from
+    validation), and error counter. Provides json()/csv()/raw() methods
+    with found/not-found signaling to eliminate cascading errors for
     expected-missing files.
+
+    Per extraction/AD0007, the upload pipeline passes a file-like
+    `AsyncFileAdapter` here directly so the zip is never materialized
+    into Pyodide's heap. `zipfile.ZipFile` accepts both paths and
+    seekable binary file-likes; the `zip_path` parameter and
+    attribute name are retained for backwards compatibility with
+    researcher-fork callers and will be renamed in PR 2.
 
     Usage:
         reader = ZipArchiveReader(zip_path, validation.archive_members, errors)
@@ -609,7 +616,12 @@ class ZipArchiveReader:
             data = result.data  # parsed dict/list
     """
 
-    def __init__(self, zip_path: str, archive_members: list[str], errors: Counter):
+    def __init__(
+        self,
+        zip_path: Union[str, IO[bytes]],
+        archive_members: list[str],
+        errors: Counter,
+    ):
         self.zip_path = zip_path
         self.archive_members = archive_members
         self.errors = errors

--- a/packages/python/port/helpers/flow_builder.py
+++ b/packages/python/port/helpers/flow_builder.py
@@ -62,29 +62,40 @@ class FlowBuilder:
             # 1. Render file prompt → receive payload
             logger.info("Prompt for file for %s", self.platform_name)
             file_prompt = self.generate_file_prompt()
+            yield from ph.emit_log("info", f"[{self.platform_name}] Upload prompt sent")
             file_result = yield ph.render_page(self.UI_TEXT["submit_file_header"], file_prompt)
 
-            # Skip: user didn't select a file
-            if file_result.__type__ not in ("PayloadFile", "PayloadString"):
+            # Skip: anything other than a PayloadFile. PayloadString/
+            # WORKERFS support was retired with extraction/AD0007.
+            # Distinguish the participant-skip case from an unexpected
+            # payload type so a legacy/mismatched worker is observable.
+            if file_result.__type__ != "PayloadFile":
                 logger.info("Skipped at file selection for %s", self.platform_name)
+                yield from ph.emit_log(
+                    "info",
+                    f"[{self.platform_name}] Upload skipped: type={file_result.__type__}",
+                )
                 return
 
-            # 2. Materialize upload to path
-            path = uploads.materialize_file(file_result)
-            file_size = getattr(file_result.value, "size", None) if file_result.__type__ == "PayloadFile" else None
-            yield from ph.emit_log("info", f"[{self.platform_name}] File received: {file_size or 'unknown'} bytes, {file_result.__type__}")
+            # AsyncFileAdapter — file-like, passed directly to validators
+            # and extractors. Never materialized to a path. See AD0007.
+            archive = file_result.value
+            yield from ph.emit_log(
+                "info",
+                f"[{self.platform_name}] Upload received: size={archive.size}",
+            )
 
-            # 3. Safety check
+            # 2. Safety check (size only — uses JS metadata, no read)
             try:
-                uploads.check_file_safety(path)
+                uploads.check_payload_size(file_result)
             except (uploads.FileTooLargeError, uploads.ChunkedExportError) as e:
                 logger.error("Safety check failed for %s: %s", self.platform_name, e)
                 yield from ph.emit_log("info", f"[{self.platform_name}] Safety check failed: {type(e).__name__}")
                 _ = yield ph.render_safety_error_page(self.platform_name, e)
                 return
 
-            # 4. Validate
-            validation = self.validate_file(path)
+            # 3. Validate
+            validation = self.validate_file(archive)
             status = validation.get_status_code_id()
             category = getattr(validation, "current_ddp_category", None)
             category_id = getattr(category, "id", "unknown") if category else "unknown"
@@ -94,7 +105,7 @@ class FlowBuilder:
             else:
                 yield from ph.emit_log("info", f"[{self.platform_name}] Validation: invalid")
 
-            # 5. If invalid → retry prompt
+            # 4. If invalid → retry prompt
             if status != 0:
                 logger.info("Invalid %s file; prompting retry", self.platform_name)
                 retry_prompt = self.generate_retry_prompt()
@@ -103,15 +114,15 @@ class FlowBuilder:
                     continue  # loop back to step 1
                 return  # user declined retry
 
-            # 6. Extract
+            # 5. Extract
             logger.info("Extracting data for %s", self.platform_name)
-            raw_result = self.extract_data(path, validation)
+            raw_result = self.extract_data(archive, validation)
             if isinstance(raw_result, Generator):
                 result = yield from raw_result
             else:
                 result = raw_result
 
-            # 7. Log extraction summary (PII-free: counts only)
+            # 6. Log extraction summary (PII-free: counts only)
             total_rows = sum(len(t.data_frame) for t in result.tables)
             if result.errors:
                 error_summary = ", ".join(f"{k}×{v}" for k, v in result.errors.items())
@@ -119,7 +130,7 @@ class FlowBuilder:
             else:
                 yield from ph.emit_log("info", f"[{self.platform_name}] Extraction complete: {len(result.tables)} tables, {total_rows} rows; errors: none")
 
-            # 8. If no tables → no-data page
+            # 7. If no tables → no-data page
             if not result.tables:
                 logger.info("No data extracted for %s", self.platform_name)
                 _ = yield ph.render_no_data_page(self.platform_name)
@@ -127,12 +138,12 @@ class FlowBuilder:
 
             break  # proceed to consent
 
-        # 9. Render consent form
+        # 8. Render consent form
         yield from ph.emit_log("info", f"[{self.platform_name}] Consent form shown")
         review_data_prompt = self.generate_review_data_prompt(result.tables)
         consent_result = yield ph.render_page(self.UI_TEXT["review_data_header"], review_data_prompt)
 
-        # 10. Donate with per-platform key
+        # 9. Donate with per-platform key
         if consent_result.__type__ == "PayloadJSON":
             reviewed_data = consent_result.value
             yield from ph.emit_log("info", f"[{self.platform_name}] Consent: accepted")

--- a/packages/python/port/helpers/uploads.py
+++ b/packages/python/port/helpers/uploads.py
@@ -1,10 +1,15 @@
-"""File materialization and safety checks.
+"""Upload safety checks.
 
-Converts browser file payloads to filesystem paths and validates
-file sizes before extraction processing.
+Validates upload size against policy limits using metadata only —
+the upload itself is never read into Pyodide's heap.
+
+See extraction/AD0007 for the streaming invariant: PayloadFile uploads
+must be passed directly to consumers (zipfile.ZipFile, validators,
+extractors) without materialization. Reading the entire payload to
+verify its size defeats this; the JS-reported `adapter.size` attribute
+is the source of truth for size policy decisions.
 """
 import logging
-import os
 
 logger = logging.getLogger(__name__)
 
@@ -20,40 +25,36 @@ class ChunkedExportError(Exception):
     """Raised when a file is exactly CHUNKED_EXPORT_SENTINEL_BYTES (split export sentinel)."""
 
 
-def materialize_file(file_result) -> str:
-    """Convert PayloadFile or PayloadString to a file path.
+def check_payload_size(file_result) -> None:
+    """Validate upload size from JS-reported metadata. No bytes read.
 
-    PayloadFile: write file_result.value (AsyncFileAdapter) contents to /tmp, return path.
-    PayloadString: return file_result.value directly (already a WORKERFS path).
-    Anything else: raise TypeError.
+    Caller is expected to handle the exception and render a safety
+    error page. FlowBuilder does this around step 1 of start_flow().
 
-    Note: /tmp is emscripten in-memory FS — files persist for worker
-    lifetime and are freed when the WebWorker terminates. No cleanup needed.
+    Args:
+        file_result: A PayloadFile-shaped object whose .value carries
+            an AsyncFileAdapter (with a .size attribute populated from
+            the JS reader at construction time).
+
+    Raises:
+        TypeError: If file_result is not a PayloadFile. PayloadString /
+            WORKERFS support was retired with extraction/AD0007.
+        ChunkedExportError: If size == CHUNKED_EXPORT_SENTINEL_BYTES
+            (split export sentinel — incomplete multi-part download).
+        FileTooLargeError: If size > MAX_FILE_SIZE_BYTES.
     """
-    if file_result.__type__ == "PayloadString":
-        return file_result.value
+    if file_result.__type__ != "PayloadFile":
+        raise TypeError(
+            f"Unsupported payload type: {file_result.__type__}. "
+            "Only PayloadFile is accepted; PayloadString/WORKERFS support "
+            "was retired in extraction/AD0007."
+        )
 
-    if file_result.__type__ == "PayloadFile":
-        adapter = file_result.value
-        file_path = f"/tmp/{adapter.name}"
-        with open(file_path, "wb") as f:
-            f.write(adapter.read())
-        logger.info("PayloadFile: wrote %d bytes to %s", adapter.size, file_path)
-        return file_path
-
-    raise TypeError(f"Unsupported payload type: {file_result.__type__}")
-
-
-def check_file_safety(path: str) -> None:
-    """Raise FileTooLargeError or ChunkedExportError if file is unsafe.
-
-    Checks: >MAX_FILE_SIZE_BYTES (too large),
-    exactly CHUNKED_EXPORT_SENTINEL_BYTES (split export sentinel).
-    """
-    size = os.path.getsize(path)
+    size = file_result.value.size  # JS metadata, no read
     if size == CHUNKED_EXPORT_SENTINEL_BYTES:
         raise ChunkedExportError(
-            f"File is exactly {CHUNKED_EXPORT_SENTINEL_BYTES} bytes — likely a chunked export sentinel"
+            f"File is exactly {CHUNKED_EXPORT_SENTINEL_BYTES} bytes — "
+            "likely a chunked export sentinel"
         )
     if size > MAX_FILE_SIZE_BYTES:
         raise FileTooLargeError(

--- a/packages/python/port/helpers/validate.py
+++ b/packages/python/port/helpers/validate.py
@@ -8,6 +8,7 @@ Which can be used and acted upon
 from dataclasses import dataclass, field
 from pathlib import Path
 from enum import Enum
+from typing import IO, Union
 import zipfile
 
 import logging
@@ -202,35 +203,39 @@ class ValidateInput:
         }
 
 
-def validate_zip(ddp_categories: list[DDPCategory], path_to_zip: str) -> ValidateInput:
+def validate_zip(
+    ddp_categories: list[DDPCategory],
+    path_to_zip: Union[str, IO[bytes]],
+) -> ValidateInput:
     """
-    Validates a DDP zip file against a list of DDP categories.
+    Validates a DDP zip archive against a list of DDP categories.
 
-    This function attempts to open and read the contents of a zip file, then uses
-    the ValidateInput class to infer the DDP category based on the files in the zip.
-    If the zip file is invalid or cannot be read, it sets an error status code (an integer greather than 0).
+    This function attempts to open and read the contents of a zip archive,
+    then uses the ValidateInput class to infer the DDP category based on the
+    files in the zip. If the archive is invalid or cannot be read, it sets
+    an error status code (an integer greater than 0).
 
     Args:
-        ddp_categories (List[DDPCategory]): A list of valid DDP categories to compare against.
-        path_to_zip (str): The file path to the zip file to be validated.
+        ddp_categories (List[DDPCategory]): A list of valid DDP categories
+            to compare against.
+        path_to_zip: Anything `zipfile.ZipFile` accepts in read mode — either
+            a filesystem path string or a seekable binary file-like object
+            (e.g. an `AsyncFileAdapter` for browser uploads). Per
+            extraction/AD0007, the upload pipeline passes the file-like
+            adapter directly so the zip is never materialized into Pyodide's
+            heap. The parameter name is retained for backwards compatibility
+            with researcher-fork callers; PR 2 (type tightening) will rename
+            this to `archive`.
 
     Returns:
-        ValidateInput: An instance of ValidateInput containing the validation results.
+        ValidateInput: An instance of ValidateInput containing the
+            validation results.
 
     Raises:
-        zipfile.BadZipFile: This exception is caught internally and results in an error status code.
-
-    Examples:
-        >>> categories = [DDPCategory(id="cat1", ddp_filetype=DDPFiletype.JSON, language=Language.EN, known_files=["file1.txt", "file2.txt"])]
-        >>> result = validate_zip(categories, "path/to/valid.zip")
-        >>> result.get_status_code_id()
-        0
-
-        >>> result = validate_zip(categories, "path/to/invalid.zip")
-        >>> result.get_status_code_id()
-        1
+        zipfile.BadZipFile: This exception is caught internally and results
+            in an error status code.
     """
-    
+
     status_codes = [
         StatusCode(id=0, description="Detected a zip from the DDPCategory list"),
         StatusCode(id=1, description="Undetected zip or bad zipfile"),

--- a/packages/python/tests/test_flow_builder.py
+++ b/packages/python/tests/test_flow_builder.py
@@ -1,7 +1,14 @@
 """Tests for FlowBuilder.start_flow() — all six flow paths.
 
-FlowBuilder now yields CommandSystemLog milestones between UI commands.
-Tests use consume_logs() to skip past log commands to the next UI/donate command.
+FlowBuilder yields CommandSystemLog milestones between UI commands.
+Tests use advance_past_logs() / start_and_skip_logs() to skip past
+log commands to the next UI/donate command.
+
+Per extraction/AD0007, PayloadFile is the only accepted upload type;
+PayloadString/WORKERFS support was retired. The upload pipeline does
+not materialize the file to a path — the AsyncFileAdapter is passed
+directly to validate_file/extract_data, and size policy is enforced
+via check_payload_size() against adapter.size before any read.
 """
 import json
 import sys
@@ -52,6 +59,18 @@ def make_payload(type_name, **attrs):
     return p
 
 
+def make_payload_file(size: int = 1024) -> MagicMock:
+    """Build a PayloadFile-shaped payload whose adapter reports `size` bytes.
+
+    AD0007: the upload-path safety check reads adapter.size from JS
+    metadata, never the bytes themselves. Tests construct adapters that
+    only need a `.size` attribute set.
+    """
+    adapter = MagicMock()
+    adapter.size = size
+    return make_payload("PayloadFile", value=adapter)
+
+
 def advance_past_logs(gen, response=None):
     """Send response to generator, skip any CommandSystemLog commands, return next non-log command."""
     cmd = gen.send(response)
@@ -71,9 +90,7 @@ def start_and_skip_logs(gen):
 class TestHappyPath:
     """User uploads valid file → extraction has data → consents → donates."""
 
-    @patch("port.helpers.flow_builder.uploads.check_file_safety")
-    @patch("port.helpers.flow_builder.uploads.materialize_file", return_value="/tmp/test.zip")
-    def test_happy_path_yields_donate(self, mock_mat, mock_safety):
+    def test_happy_path_yields_donate(self):
         flow = StubFlow()
         gen = flow.start_flow()
 
@@ -82,8 +99,7 @@ class TestHappyPath:
         assert isinstance(cmd, CommandUIRender)
 
         # Step 2: user uploads file → milestones → consent form
-        file_payload = make_payload("PayloadFile", value=MagicMock())
-        cmd = advance_past_logs(gen, file_payload)
+        cmd = advance_past_logs(gen, make_payload_file())
         assert isinstance(cmd, CommandUIRender)
 
         # Step 3: user consents → milestones → donate command
@@ -100,9 +116,7 @@ class TestHappyPath:
 class TestRetryPath:
     """User uploads invalid file → retries → uploads valid file → succeeds."""
 
-    @patch("port.helpers.flow_builder.uploads.check_file_safety")
-    @patch("port.helpers.flow_builder.uploads.materialize_file", return_value="/tmp/test.zip")
-    def test_retry_loops_back(self, mock_mat, mock_safety):
+    def test_retry_loops_back(self):
         call_count = [0]
         flow = StubFlow()
 
@@ -122,7 +136,7 @@ class TestRetryPath:
         assert isinstance(cmd, CommandUIRender)
 
         # Upload invalid file → milestones → retry prompt
-        cmd = advance_past_logs(gen, make_payload("PayloadString", value="/tmp/bad.zip"))
+        cmd = advance_past_logs(gen, make_payload_file())
         assert isinstance(cmd, CommandUIRender)
 
         # User clicks "Try again" → loops back → file prompt
@@ -130,12 +144,12 @@ class TestRetryPath:
         assert isinstance(cmd, CommandUIRender)
 
         # Upload valid file → milestones → consent form
-        cmd = advance_past_logs(gen, make_payload("PayloadString", value="/tmp/good.zip"))
+        cmd = advance_past_logs(gen, make_payload_file())
         assert isinstance(cmd, CommandUIRender)
 
 
 class TestSkipPath:
-    """User skips file selection (not PayloadFile or PayloadString)."""
+    """User skips file selection (anything other than PayloadFile)."""
 
     def test_skip_returns_immediately(self):
         flow = StubFlow()
@@ -145,17 +159,29 @@ class TestSkipPath:
         cmd = start_and_skip_logs(gen)
         assert isinstance(cmd, CommandUIRender)
 
-        # User skips
+        # User skips with non-PayloadFile response — emits an
+        # "Upload skipped" diagnostic log, then returns.
         with pytest.raises(StopIteration):
-            gen.send(make_payload("PayloadFalse"))
+            advance_past_logs(gen, make_payload("PayloadFalse"))
+
+    def test_payload_string_now_treated_as_skip(self):
+        """SRC compat dropped per AD0007: PayloadString is not a valid upload."""
+        flow = StubFlow()
+        gen = flow.start_flow()
+
+        cmd = start_and_skip_logs(gen)
+        assert isinstance(cmd, CommandUIRender)
+
+        # PayloadString hits the same skip branch as any other non-PayloadFile,
+        # which now emits an "Upload skipped" diagnostic log before returning.
+        with pytest.raises(StopIteration):
+            advance_past_logs(gen, make_payload("PayloadString", value="/tmp/legacy.zip"))
 
 
 class TestNoDataPath:
     """Valid file but extraction returns empty table list."""
 
-    @patch("port.helpers.flow_builder.uploads.check_file_safety")
-    @patch("port.helpers.flow_builder.uploads.materialize_file", return_value="/tmp/test.zip")
-    def test_no_data_shows_page_then_returns(self, mock_mat, mock_safety):
+    def test_no_data_shows_page_then_returns(self):
         flow = StubFlow(tables=[])
         gen = flow.start_flow()
 
@@ -164,7 +190,7 @@ class TestNoDataPath:
         assert isinstance(cmd, CommandUIRender)
 
         # Upload valid file → milestones → no-data page
-        cmd = advance_past_logs(gen, make_payload("PayloadString", value="/tmp/empty.zip"))
+        cmd = advance_past_logs(gen, make_payload_file())
         assert isinstance(cmd, CommandUIRender)
 
         # User acknowledges
@@ -173,11 +199,13 @@ class TestNoDataPath:
 
 
 class TestSafetyErrorPath:
-    """File fails safety check."""
+    """File fails safety check (oversize / chunked-export sentinel)."""
 
-    @patch("port.helpers.flow_builder.uploads.check_file_safety", side_effect=FileTooLargeError("too big"))
-    @patch("port.helpers.flow_builder.uploads.materialize_file", return_value="/tmp/test.zip")
-    def test_safety_error_shows_page_then_returns(self, mock_mat, mock_safety):
+    @patch(
+        "port.helpers.flow_builder.uploads.check_payload_size",
+        side_effect=FileTooLargeError("too big"),
+    )
+    def test_safety_error_shows_page_then_returns(self, mock_check):
         flow = StubFlow()
         gen = flow.start_flow()
 
@@ -186,7 +214,7 @@ class TestSafetyErrorPath:
         assert isinstance(cmd, CommandUIRender)
 
         # Upload file that fails safety → milestones → safety error page
-        cmd = advance_past_logs(gen, make_payload("PayloadFile", value=MagicMock()))
+        cmd = advance_past_logs(gen, make_payload_file(size=3 * 1024**3))
         assert isinstance(cmd, CommandUIRender)
 
         # User acknowledges
@@ -198,9 +226,7 @@ class TestDonateFailurePath:
     """Donation fails after consent."""
 
     @patch("port.helpers.flow_builder.ph.handle_donate_result", return_value=False)
-    @patch("port.helpers.flow_builder.uploads.check_file_safety")
-    @patch("port.helpers.flow_builder.uploads.materialize_file", return_value="/tmp/test.zip")
-    def test_donate_failure_shows_page_then_returns(self, mock_mat, mock_safety, mock_handle):
+    def test_donate_failure_shows_page_then_returns(self, mock_handle):
         flow = StubFlow()
         gen = flow.start_flow()
 
@@ -208,7 +234,7 @@ class TestDonateFailurePath:
         cmd = start_and_skip_logs(gen)
 
         # Upload valid file → milestones → consent form
-        cmd = advance_past_logs(gen, make_payload("PayloadString", value="/tmp/test.zip"))
+        cmd = advance_past_logs(gen, make_payload_file())
         assert isinstance(cmd, CommandUIRender)
 
         # User consents → milestones → donate command
@@ -231,13 +257,57 @@ class TestSessionIdType:
 
 
 class TestDonateKeyFormat:
-    @patch("port.helpers.flow_builder.uploads.check_file_safety")
-    @patch("port.helpers.flow_builder.uploads.materialize_file", return_value="/tmp/test.zip")
-    def test_donate_key_includes_platform(self, mock_mat, mock_safety):
+    def test_donate_key_includes_platform(self):
         """Donate key should be '{session_id}-{platform_name.lower()}'."""
         flow = StubFlow(session_id="sess-42")
         gen = flow.start_flow()
         start_and_skip_logs(gen)  # file prompt
-        advance_past_logs(gen, make_payload("PayloadString", value="/tmp/test.zip"))  # consent form
+        advance_past_logs(gen, make_payload_file())  # consent form
         cmd = advance_past_logs(gen, make_payload("PayloadJSON", value="{}"))  # donate
         assert cmd.key == "sess-42-testplatform"
+
+
+class TestUploadAdapterPassthrough:
+    """Verify the adapter (file_result.value) is passed to validate/extract,
+    not a path string. AD0007 streaming invariant.
+    """
+
+    def test_validate_file_receives_adapter(self):
+        """validate_file is called with file_result.value, not a path."""
+        flow = StubFlow()
+        observed = []
+        original_validate = flow.validate_file
+
+        def spy_validate(file):
+            observed.append(file)
+            return original_validate(file)
+
+        flow.validate_file = spy_validate
+
+        gen = flow.start_flow()
+        start_and_skip_logs(gen)
+        adapter = MagicMock()
+        adapter.size = 1024
+        advance_past_logs(gen, make_payload("PayloadFile", value=adapter))
+
+        assert observed == [adapter]
+
+    def test_extract_data_receives_adapter(self):
+        """extract_data is called with file_result.value, not a path."""
+        flow = StubFlow()
+        observed = []
+        original_extract = flow.extract_data
+
+        def spy_extract(file, validation):
+            observed.append(file)
+            return original_extract(file, validation)
+
+        flow.extract_data = spy_extract
+
+        gen = flow.start_flow()
+        start_and_skip_logs(gen)
+        adapter = MagicMock()
+        adapter.size = 1024
+        advance_past_logs(gen, make_payload("PayloadFile", value=adapter))
+
+        assert observed == [adapter]

--- a/packages/python/tests/test_uploads.py
+++ b/packages/python/tests/test_uploads.py
@@ -1,88 +1,195 @@
-"""Tests for file materialization and safety checks."""
-import os
+"""Tests for upload safety checks and streaming invariant.
+
+See extraction/AD0007 for the streaming invariant:
+PayloadFile uploads must reach consumers (zipfile.ZipFile, validators,
+extractors) without materialization, and size policy decisions must
+use JS-reported metadata rather than reading the upload.
+"""
+import io
 import sys
-import pytest
+import zipfile
 from unittest.mock import MagicMock
 
-# Mock js module before any port imports
+# Mock js module before any port imports (Pyodide-only at runtime).
 sys.modules["js"] = MagicMock()
 
+import pytest
+
 from port.helpers.uploads import (
-    materialize_file,
-    check_file_safety,
+    check_payload_size,
     FileTooLargeError,
     ChunkedExportError,
     MAX_FILE_SIZE_BYTES,
+    CHUNKED_EXPORT_SENTINEL_BYTES,
 )
 
 
-class TestMaterializeFile:
-    def test_payload_string_returns_path(self):
-        """PayloadString: value is returned as-is (it's already a path)."""
+def _payload_file(size: int) -> MagicMock:
+    """Build a PayloadFile-shaped mock with the given adapter size."""
+    adapter = MagicMock()
+    adapter.size = size
+    payload = MagicMock()
+    payload.__type__ = "PayloadFile"
+    payload.value = adapter
+    return payload
+
+
+class TestCheckPayloadSize:
+    def test_normal_size_passes(self):
+        """Sub-limit PayloadFile passes without raising."""
+        check_payload_size(_payload_file(100 * 1024))  # 100 KiB
+
+    def test_just_below_limit_passes(self):
+        """Exactly MAX_FILE_SIZE_BYTES - 1 passes."""
+        check_payload_size(_payload_file(MAX_FILE_SIZE_BYTES - 1))
+
+    def test_above_limit_raises_too_large(self):
+        """Strictly above MAX_FILE_SIZE_BYTES raises FileTooLargeError."""
+        with pytest.raises(FileTooLargeError):
+            check_payload_size(_payload_file(MAX_FILE_SIZE_BYTES + 1))
+
+    def test_exact_sentinel_raises_chunked_export(self):
+        """Exactly CHUNKED_EXPORT_SENTINEL_BYTES raises ChunkedExportError."""
+        with pytest.raises(ChunkedExportError):
+            check_payload_size(_payload_file(CHUNKED_EXPORT_SENTINEL_BYTES))
+
+    def test_payload_string_raises_type_error(self):
+        """PayloadString is no longer accepted (SRC compat dropped per AD0007)."""
         payload = MagicMock()
         payload.__type__ = "PayloadString"
-        payload.value = "/some/path/file.zip"
-        assert materialize_file(payload) == "/some/path/file.zip"
+        payload.value = "/some/path"
+        with pytest.raises(TypeError, match="Unsupported payload type"):
+            check_payload_size(payload)
 
-    def test_payload_file_writes_to_tmp(self, tmp_path):
-        """PayloadFile: contents are written to /tmp and path is returned."""
-        content = b"fake zip content"
+    def test_unknown_type_raises_type_error(self):
+        """Any non-PayloadFile type raises TypeError."""
+        payload = MagicMock()
+        payload.__type__ = "PayloadJSON"
+        with pytest.raises(TypeError, match="Unsupported payload type"):
+            check_payload_size(payload)
+
+    def test_does_not_read_adapter(self):
+        """Size is taken from .size metadata; .read() is never called.
+
+        This is the core invariant of AD0007 — verifying upload size
+        must not trigger the failure mode it is meant to prevent.
+        """
         adapter = MagicMock()
-        adapter.name = "test.zip"
-        adapter.read.return_value = content
-        adapter.size = len(content)
-
+        adapter.size = MAX_FILE_SIZE_BYTES + 1
         payload = MagicMock()
         payload.__type__ = "PayloadFile"
         payload.value = adapter
 
-        result = materialize_file(payload)
-        assert result == "/tmp/test.zip"
-        assert os.path.exists(result)
-        with open(result, "rb") as f:
-            assert f.read() == content
+        with pytest.raises(FileTooLargeError):
+            check_payload_size(payload)
 
-        # Cleanup
-        os.unlink(result)
-
-    def test_unknown_type_raises_type_error(self):
-        """Unknown payload type raises TypeError."""
-        payload = MagicMock()
-        payload.__type__ = "PayloadJSON"
-        with pytest.raises(TypeError, match="Unsupported payload type"):
-            materialize_file(payload)
+        adapter.read.assert_not_called()
+        adapter.readSlice.assert_not_called()
 
 
-class TestCheckFileSafety:
-    def test_normal_file_passes(self, tmp_path):
-        """Normal-sized file passes safety check."""
-        f = tmp_path / "ok.zip"
-        f.write_bytes(b"x" * 100)
-        check_file_safety(str(f))  # Should not raise
+class _TrackingAdapter(io.BytesIO):
+    """A BytesIO-backed adapter that records every read() call.
 
-    def test_too_large_raises(self, tmp_path):
-        """File exceeding MAX_FILE_SIZE_BYTES raises FileTooLargeError."""
-        f = tmp_path / "big.zip"
-        f.write_bytes(b"")  # Create empty file
+    Behaves exactly like a seekable binary file-like (which is what
+    zipfile.ZipFile expects) but logs the size argument of each read
+    so tests can assert no full-file read occurs.
+    """
 
-        # Mock os.path.getsize to avoid creating a 2GB file
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "os.path.getsize",
-                lambda p: MAX_FILE_SIZE_BYTES + 1,
-            )
-            with pytest.raises(FileTooLargeError):
-                check_file_safety(str(f))
+    def __init__(self, content: bytes):
+        super().__init__(content)
+        self.read_calls: list[int] = []
 
-    def test_exact_sentinel_raises_chunked_export(self, tmp_path):
-        """File exactly at sentinel size raises ChunkedExportError."""
-        f = tmp_path / "chunked.zip"
-        f.write_bytes(b"")
+    def read(self, size: int | None = -1) -> bytes:
+        self.read_calls.append(size if size is not None else -1)
+        return super().read(size)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "os.path.getsize",
-                lambda p: MAX_FILE_SIZE_BYTES,
-            )
-            with pytest.raises(ChunkedExportError):
-                check_file_safety(str(f))
+
+class TestStreamingInvariant:
+    """zipfile.ZipFile must never issue read(-1) against an upload-path
+    file-like. A full-file read is what triggers
+    FileReaderSync.readAsArrayBuffer above 2 GiB. See AD0007.
+    """
+
+    def _build_zip_bytes(self) -> bytes:
+        """Build a small in-memory zip with several entries."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("a.json", '{"k": "v"}')
+            zf.writestr("nested/b.json", '{"k2": "v2"}')
+            zf.writestr("c.csv", "col1,col2\n1,2\n")
+        return buf.getvalue()
+
+    def test_zipfile_open_does_not_full_read(self):
+        """Opening a ZipFile and listing members issues no read(-1)."""
+        adapter = _TrackingAdapter(self._build_zip_bytes())
+        with zipfile.ZipFile(adapter, "r") as zf:
+            zf.namelist()
+        assert -1 not in adapter.read_calls
+
+    def test_zipfile_extract_does_not_full_read(self):
+        """Reading a member never issues read(-1)."""
+        adapter = _TrackingAdapter(self._build_zip_bytes())
+        with zipfile.ZipFile(adapter, "r") as zf:
+            data = zf.read("a.json")
+        assert data == b'{"k": "v"}'
+        assert -1 not in adapter.read_calls
+
+    def test_zipfile_open_close_reuse(self):
+        """Opening the same adapter in successive ZipFile contexts works.
+
+        ZipArchiveReader._read_member_bytes opens a fresh ZipFile per
+        member access. The adapter must survive being passed to
+        successive contexts.
+        """
+        adapter = _TrackingAdapter(self._build_zip_bytes())
+        with zipfile.ZipFile(adapter, "r") as zf:
+            zf.namelist()
+        with zipfile.ZipFile(adapter, "r") as zf:
+            zf.read("nested/b.json")
+        assert -1 not in adapter.read_calls
+
+
+class TestAsyncFileAdapterContract:
+    """Verify the real AsyncFileAdapter (not a mock) implements the
+    file-like contract zipfile.ZipFile requires.
+    """
+
+    def test_adapter_provides_seek_tell_read_size(self):
+        """Real AsyncFileAdapter has the methods/attributes streaming requires."""
+        from port.api.file_utils import AsyncFileAdapter
+
+        # Fake JS reader: returns the requested slice as a JS-array proxy.
+        class FakeJsArray:
+            def __init__(self, data: bytes):
+                self._data = data
+
+            def to_py(self) -> bytes:
+                return self._data
+
+        class FakeJsReader:
+            def __init__(self, content: bytes):
+                self._content = content
+                self.size = len(content)
+                self.name = "fake.zip"
+
+            def readSlice(self, start: int, end: int):
+                return FakeJsArray(self._content[start:end])
+
+        content = b"abcdefghijklmnop"
+        adapter = AsyncFileAdapter(FakeJsReader(content))
+
+        assert adapter.size == len(content)
+        assert adapter.readable()
+        assert adapter.seekable()
+
+        # Bounded read.
+        assert adapter.read(4) == b"abcd"
+        assert adapter.tell() == 4
+
+        # Seek + bounded read.
+        adapter.seek(8)
+        assert adapter.read(4) == b"ijkl"
+
+        # Seek-from-end.
+        adapter.seek(-2, 2)
+        assert adapter.read(2) == b"op"

--- a/packages/python/tests/test_validate.py
+++ b/packages/python/tests/test_validate.py
@@ -1,4 +1,5 @@
 """Tests for ValidateInput archive_members caching."""
+import io
 import sys
 import zipfile
 from unittest.mock import MagicMock
@@ -59,3 +60,30 @@ class TestArchiveMembers:
         )]
         v = ValidateInput(status_codes, categories)
         assert v.archive_members == []
+
+
+class TestFileLikeAcceptance:
+    """validate_zip must accept a seekable binary file-like (e.g. AsyncFileAdapter).
+
+    Per extraction/AD0007, the upload pipeline passes the AsyncFileAdapter
+    directly so the zip is never materialized to a path.
+    """
+
+    def test_validate_zip_accepts_bytesio(self):
+        """validate_zip works against an in-memory BytesIO archive."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("data/following.json", '{}')
+            zf.writestr("data/posts.json", '{}')
+        buf.seek(0)
+
+        categories = [DDPCategory(
+            id="test", ddp_filetype=DDPFiletype.JSON,
+            language=Language.EN, known_files=["following.json", "posts.json"]
+        )]
+        result = validate_zip(categories, buf)
+        assert "data/following.json" in result.archive_members
+        assert "data/posts.json" in result.archive_members
+        # Detected as the test category, not unknown.
+        assert result.current_ddp_category is not None
+        assert result.current_ddp_category.id == "test"

--- a/packages/python/tests/test_zip_archive_reader.py
+++ b/packages/python/tests/test_zip_archive_reader.py
@@ -166,3 +166,45 @@ class TestJsonAll:
         reader = ZipArchiveReader(path, members, Counter())
         results = reader.json_all(r"nonexistent_\d+\.json$")
         assert results == []
+
+
+class TestFileLikeAcceptance:
+    """ZipArchiveReader must accept a seekable binary file-like archive
+    (e.g. AsyncFileAdapter), not just a path string. AD0007.
+    """
+
+    @pytest.fixture
+    def sample_archive_buf(self):
+        """Build the same archive as `sample_zip` but as a BytesIO buffer."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("data/following.json", json.dumps({"relationships_following": []}))
+            zf.writestr("ratings.csv", "Title,Rating\nMovie A,5\nMovie B,3\n")
+        members = ["data/following.json", "ratings.csv"]
+        return buf, members
+
+    def test_json_extraction_from_bytesio(self, sample_archive_buf):
+        """Reader extracts JSON from a BytesIO-backed archive."""
+        buf, members = sample_archive_buf
+        reader = ZipArchiveReader(buf, members, Counter())
+        result = reader.json("data/following.json")
+        assert result.found is True
+        assert result.data == {"relationships_following": []}
+
+    def test_csv_extraction_from_bytesio(self, sample_archive_buf):
+        """Reader extracts CSV from a BytesIO-backed archive."""
+        buf, members = sample_archive_buf
+        reader = ZipArchiveReader(buf, members, Counter())
+        result = reader.csv("ratings.csv")
+        assert result.found is True
+        assert len(result.data) == 2
+
+    def test_multiple_reads_from_same_bytesio(self, sample_archive_buf):
+        """Successive ZipFile contexts on the same archive object work
+        (mirrors AsyncFileAdapter reuse across member accesses).
+        """
+        buf, members = sample_archive_buf
+        reader = ZipArchiveReader(buf, members, Counter())
+        r1 = reader.json("data/following.json")
+        r2 = reader.csv("ratings.csv")
+        assert r1.found and r2.found


### PR DESCRIPTION
Closes regression introduced in 68c59d8. Restores the streaming intent of upstream PR #482.

Production reproduction confirmed against next.eyra.co with a 2.5 GiB Facebook fixture (FileReaderSync NotReadableError when materialize_file calls adapter.read() with no size).

PR 1 of 3:
  - PR 1 (this): the fix + AD0007 + tests
  - PR 2: type tightening + dead PayloadString JS cleanup + parameter renames (zip_path → archive)
  - PR 3: project CLAUDE.md + doc drift fixes
                                                                       
Fixes #61