### PR TITLE
Refactor/tighten archive types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release on tag
+
+# When an annotated tag matching `v*` is pushed, extract that
+# version's section from CHANGELOG.md and create a GitHub release
+# using it as the body. This lets `git push origin vX.Y.Z` be the
+# entire release flow — no `gh` CLI, no web UI, no PAT needed
+# beyond the workflow's automatic GITHUB_TOKEN.
+#
+# Convention: each released version has a heading of the form
+#   ## vX.Y.Z — YYYY-MM-DD
+# in CHANGELOG.md. The workflow extracts the body between that
+# heading and the next `## v[0-9]` heading.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write    # required to create releases
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Extract release notes from CHANGELOG
+        env:
+          # Bind the tag name (e.g. "v2.0.1") into a shell variable
+          # via env: rather than ${{ }} interpolation. Safer pattern
+          # for any field GitHub populates from a context, even when
+          # the field (a tag name) is not user-content-controlled.
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG_NAME#v}"
+          awk -v ver="$version" '
+            $0 ~ ("^## v" ver " ") { flag = 1; next }
+            flag && /^## v[0-9]/   { exit }
+            flag                   { print }
+          ' CHANGELOG.md > /tmp/notes.md
+
+          if [ ! -s /tmp/notes.md ]; then
+            echo "::error::No CHANGELOG section found for ${TAG_NAME}. Expected '## ${TAG_NAME} — <date>' heading in CHANGELOG.md."
+            exit 1
+          fi
+
+          echo "::group::Extracted notes"
+          cat /tmp/notes.md
+          echo "::endgroup::"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: /tmp/notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Earlier releases used sequential numbering (#1-#5) matching the upstream
 
 ## [Unreleased]
 
+### Changed
+
+* **Breaking:** `ZipArchiveReader.__init__` and `validate.validate_zip`
+  narrow their archive parameter from `Union[str, IO[bytes]]`
+  (introduced in v2.0.1) to a new `SeekableBinaryReader` Protocol
+  (`read | seek | tell`) — path strings are no longer accepted. The
+  upload pipeline passes an `AsyncFileAdapter` directly; tests
+  construct fixtures via `io.BytesIO`. Type narrowing makes the
+  streaming invariant from `extraction/AD0007` checkable: passing a
+  `str` path to a consumer fails Pyright. CI does not currently run
+  type-checking, so this is a local / IDE / code-review aid rather
+  than a CI gate. Combined with the absence of `materialize_file()`
+  (deleted in v2.0.1), the protection is defense-in-depth — the
+  offending function no longer exists, and consumer signatures
+  reject path inputs.
+* **Breaking:** Archive parameter rename — `validate_zip(path_to_zip=…)`
+  and `ZipArchiveReader(zip_path=…)` keyword arguments are now
+  `archive=…`. The `ZipArchiveReader.zip_path` attribute is renamed to
+  `ZipArchiveReader.archive`. Positional callers are unaffected.
+
 ## v2.0.1 — 2026-05-04
 
 ### Fixed

--- a/packages/python/port/api/file_utils.py
+++ b/packages/python/port/api/file_utils.py
@@ -5,8 +5,34 @@ This module provides adapters to bridge async browser File APIs with
 synchronous Python file operations, avoiding the need to copy entire
 files into Pyodide's virtual filesystem.
 """
+from typing import Protocol, runtime_checkable
 
 import js
+
+
+@runtime_checkable
+class SeekableBinaryReader(Protocol):
+    """File-like contract for upload-pipeline consumers.
+
+    Per extraction/AD0007, archive-consuming functions
+    (zipfile.ZipFile, validate.validate_zip,
+    extraction_helpers.ZipArchiveReader, per-platform
+    extraction()/validate_file()/extract_data()) accept this
+    Protocol — never a path string. Path inputs are forbidden in the
+    upload pipeline because the only way to obtain a path from a
+    PayloadFile is to materialize it, which defeats streaming and
+    re-introduces the FileReaderSync ~2 GiB ArrayBuffer cap (see
+    issue #61).
+
+    AsyncFileAdapter satisfies this Protocol. Tests construct
+    fixtures via io.BytesIO, which also satisfies it.
+    """
+
+    def read(self, size: int = -1, /) -> bytes: ...
+
+    def seek(self, offset: int, whence: int = 0, /) -> int: ...
+
+    def tell(self) -> int: ...
 
 
 class AsyncFileAdapter:

--- a/packages/python/port/helpers/extraction_helpers.py
+++ b/packages/python/port/helpers/extraction_helpers.py
@@ -7,9 +7,11 @@ import logging
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import IO, Any, Callable, Union
+from typing import Any, Callable
 from pathlib import Path
 import zipfile
+
+from port.api.file_utils import SeekableBinaryReader
 import csv
 import io
 import json
@@ -597,20 +599,18 @@ class RawExtractionResult:
 class ZipArchiveReader:
     """Reads files from a zip archive using cached member inventory.
 
-    Encapsulates the zip path or file-like, archive member list (from
-    validation), and error counter. Provides json()/csv()/raw() methods
-    with found/not-found signaling to eliminate cascading errors for
-    expected-missing files.
+    Encapsulates a seekable binary archive (`SeekableBinaryReader`),
+    archive member list (from validation), and error counter. Provides
+    json()/csv()/raw() methods with found/not-found signaling to
+    eliminate cascading errors for expected-missing files.
 
-    Per extraction/AD0007, the upload pipeline passes a file-like
-    `AsyncFileAdapter` here directly so the zip is never materialized
-    into Pyodide's heap. `zipfile.ZipFile` accepts both paths and
-    seekable binary file-likes; the `zip_path` parameter and
-    attribute name are retained for backwards compatibility with
-    researcher-fork callers and will be renamed in PR 2.
+    Per extraction/AD0007, the upload pipeline passes the
+    `AsyncFileAdapter` from a browser upload here directly so the zip
+    is never materialized into Pyodide's heap. Path-string inputs are
+    not accepted; tests construct fixtures via `io.BytesIO`.
 
     Usage:
-        reader = ZipArchiveReader(zip_path, validation.archive_members, errors)
+        reader = ZipArchiveReader(archive, validation.archive_members, errors)
         result = reader.json("following.json")
         if result.found:
             data = result.data  # parsed dict/list
@@ -618,11 +618,11 @@ class ZipArchiveReader:
 
     def __init__(
         self,
-        zip_path: Union[str, IO[bytes]],
+        archive: SeekableBinaryReader,
         archive_members: list[str],
         errors: Counter,
     ):
-        self.zip_path = zip_path
+        self.archive = archive
         self.archive_members = archive_members
         self.errors = errors
 
@@ -659,7 +659,7 @@ class ZipArchiveReader:
     def _read_member_bytes(self, member_path: str) -> io.BytesIO:
         """Read a specific member from the zip by exact path."""
         try:
-            with zipfile.ZipFile(self.zip_path, "r") as zf:
+            with zipfile.ZipFile(self.archive, "r") as zf:
                 return io.BytesIO(zf.read(member_path))
         except Exception as e:
             logger.error("Error reading zip member: %s", type(e).__name__)

--- a/packages/python/port/helpers/validate.py
+++ b/packages/python/port/helpers/validate.py
@@ -8,10 +8,11 @@ Which can be used and acted upon
 from dataclasses import dataclass, field
 from pathlib import Path
 from enum import Enum
-from typing import IO, Union
 import zipfile
 
 import logging
+
+from port.api.file_utils import SeekableBinaryReader
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +206,7 @@ class ValidateInput:
 
 def validate_zip(
     ddp_categories: list[DDPCategory],
-    path_to_zip: Union[str, IO[bytes]],
+    archive: SeekableBinaryReader,
 ) -> ValidateInput:
     """
     Validates a DDP zip archive against a list of DDP categories.
@@ -218,14 +219,11 @@ def validate_zip(
     Args:
         ddp_categories (List[DDPCategory]): A list of valid DDP categories
             to compare against.
-        path_to_zip: Anything `zipfile.ZipFile` accepts in read mode — either
-            a filesystem path string or a seekable binary file-like object
-            (e.g. an `AsyncFileAdapter` for browser uploads). Per
-            extraction/AD0007, the upload pipeline passes the file-like
-            adapter directly so the zip is never materialized into Pyodide's
-            heap. The parameter name is retained for backwards compatibility
-            with researcher-fork callers; PR 2 (type tightening) will rename
-            this to `archive`.
+        archive: A seekable binary file-like object — typically an
+            `AsyncFileAdapter` from a browser upload, or an `io.BytesIO`
+            in tests. Per extraction/AD0007, the upload pipeline never
+            materializes uploads to a path; consumers accept the file-like
+            adapter directly to avoid `FileReaderSync`'s ~2 GiB cap.
 
     Returns:
         ValidateInput: An instance of ValidateInput containing the
@@ -244,7 +242,7 @@ def validate_zip(
 
     try:
         paths = []
-        with zipfile.ZipFile(path_to_zip, "r") as zf:
+        with zipfile.ZipFile(archive, "r") as zf:
             all_members = zf.namelist()
             for f in all_members:
                 p = Path(f)

--- a/packages/python/tests/test_validate.py
+++ b/packages/python/tests/test_validate.py
@@ -1,4 +1,9 @@
-"""Tests for ValidateInput archive_members caching."""
+"""Tests for ValidateInput archive_members caching.
+
+Per extraction/AD0007, validate_zip accepts a seekable binary file-like
+(SeekableBinaryReader Protocol) — never a path string. Test fixtures use
+io.BytesIO; production callers pass an AsyncFileAdapter directly.
+"""
 import io
 import sys
 import zipfile
@@ -9,46 +14,55 @@ sys.modules["js"] = MagicMock()
 from port.helpers.validate import ValidateInput, validate_zip, DDPCategory, DDPFiletype, Language, StatusCode
 
 
+def _build_archive(*entries: tuple[str, str | bytes]) -> io.BytesIO:
+    """Build an in-memory zip with the given (name, content) entries."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in entries:
+            zf.writestr(name, content)
+    buf.seek(0)
+    return buf
+
+
 class TestArchiveMembers:
-    def test_validate_zip_populates_archive_members(self, tmp_path):
+    def test_validate_zip_populates_archive_members(self):
         """validate_zip stores full member paths on ValidateInput."""
-        zip_path = tmp_path / "test.zip"
-        with zipfile.ZipFile(zip_path, "w") as zf:
-            zf.writestr("data/following.json", '{}')
-            zf.writestr("data/posts.json", '{}')
+        archive = _build_archive(
+            ("data/following.json", '{}'),
+            ("data/posts.json", '{}'),
+        )
 
         categories = [DDPCategory(
             id="test", ddp_filetype=DDPFiletype.JSON,
             language=Language.EN, known_files=["following.json", "posts.json"]
         )]
-        result = validate_zip(categories, str(zip_path))
+        result = validate_zip(categories, archive)
         assert "data/following.json" in result.archive_members
         assert "data/posts.json" in result.archive_members
 
-    def test_archive_members_excluded_from_repr(self, tmp_path):
+    def test_archive_members_excluded_from_repr(self):
         """archive_members must not appear in repr (PII safety)."""
-        zip_path = tmp_path / "test.zip"
-        with zipfile.ZipFile(zip_path, "w") as zf:
-            zf.writestr("messages/inbox/contact_name_123/photo.jpg", b"")
-            zf.writestr("following.json", '{}')
+        archive = _build_archive(
+            ("messages/inbox/contact_name_123/photo.jpg", b""),
+            ("following.json", '{}'),
+        )
 
         categories = [DDPCategory(
             id="test", ddp_filetype=DDPFiletype.JSON,
             language=Language.EN, known_files=["following.json"]
         )]
-        result = validate_zip(categories, str(zip_path))
+        result = validate_zip(categories, archive)
         assert "contact_name_123" not in repr(result)
 
-    def test_archive_members_empty_on_bad_zip(self, tmp_path):
-        """archive_members stays empty if zip is invalid."""
-        bad_path = tmp_path / "bad.zip"
-        bad_path.write_bytes(b"not a zip")
+    def test_archive_members_empty_on_bad_zip(self):
+        """archive_members stays empty if archive is not a valid zip."""
+        bad_archive = io.BytesIO(b"not a zip")
 
         categories = [DDPCategory(
             id="test", ddp_filetype=DDPFiletype.JSON,
             language=Language.EN, known_files=["file.json"]
         )]
-        result = validate_zip(categories, str(bad_path))
+        result = validate_zip(categories, bad_archive)
         assert result.archive_members == []
 
     def test_archive_members_default_empty(self):
@@ -61,29 +75,17 @@ class TestArchiveMembers:
         v = ValidateInput(status_codes, categories)
         assert v.archive_members == []
 
-
-class TestFileLikeAcceptance:
-    """validate_zip must accept a seekable binary file-like (e.g. AsyncFileAdapter).
-
-    Per extraction/AD0007, the upload pipeline passes the AsyncFileAdapter
-    directly so the zip is never materialized to a path.
-    """
-
-    def test_validate_zip_accepts_bytesio(self):
-        """validate_zip works against an in-memory BytesIO archive."""
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, "w") as zf:
-            zf.writestr("data/following.json", '{}')
-            zf.writestr("data/posts.json", '{}')
-        buf.seek(0)
+    def test_validate_zip_detects_category_against_bytesio(self):
+        """validate_zip correctly identifies the DDP category for a file-like archive."""
+        archive = _build_archive(
+            ("data/following.json", '{}'),
+            ("data/posts.json", '{}'),
+        )
 
         categories = [DDPCategory(
             id="test", ddp_filetype=DDPFiletype.JSON,
             language=Language.EN, known_files=["following.json", "posts.json"]
         )]
-        result = validate_zip(categories, buf)
-        assert "data/following.json" in result.archive_members
-        assert "data/posts.json" in result.archive_members
-        # Detected as the test category, not unknown.
+        result = validate_zip(categories, archive)
         assert result.current_ddp_category is not None
         assert result.current_ddp_category.id == "test"

--- a/packages/python/tests/test_zip_archive_reader.py
+++ b/packages/python/tests/test_zip_archive_reader.py
@@ -1,4 +1,9 @@
-"""Tests for ZipArchiveReader — member resolution, extraction, result types."""
+"""Tests for ZipArchiveReader — member resolution, extraction, result types.
+
+Per extraction/AD0007, ZipArchiveReader accepts a seekable binary file-like
+(SeekableBinaryReader Protocol) — never a path string. Test fixtures use
+io.BytesIO; production callers pass an AsyncFileAdapter directly.
+"""
 import sys
 import io
 import json
@@ -18,95 +23,108 @@ from port.helpers.extraction_helpers import (
 )
 
 
+def _build_archive(*entries: tuple[str, str | bytes]) -> io.BytesIO:
+    """Build an in-memory zip with the given (name, content) entries."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in entries:
+            zf.writestr(name, content)
+    buf.seek(0)
+    return buf
+
+
 @pytest.fixture
-def sample_zip(tmp_path):
-    """Create a zip with known structure for testing."""
-    zip_path = tmp_path / "test.zip"
-    with zipfile.ZipFile(zip_path, "w") as zf:
-        zf.writestr("data/following.json", json.dumps({"relationships_following": []}))
-        zf.writestr("data/nested/following.json", json.dumps({"other": "data"}))
-        zf.writestr("data/foo_following.json", json.dumps({"wrong": "file"}))
-        zf.writestr("ratings.csv", "Title,Rating\nMovie A,5\nMovie B,3\n")
-        zf.writestr("Bookmarks.html", "<html><body><a href='http://example.com'>Example</a></body></html>")
-        zf.writestr("post_comments_1.json", json.dumps([{"comment": "one"}]))
-        zf.writestr("post_comments_2.json", json.dumps([{"comment": "two"}]))
+def sample_zip():
+    """Build a fresh in-memory archive with known structure for testing.
+
+    Returns (archive, members). The archive is a BytesIO satisfying
+    SeekableBinaryReader. Each test gets its own fresh BytesIO so seek
+    positions don't leak between tests.
+    """
+    archive = _build_archive(
+        ("data/following.json", json.dumps({"relationships_following": []})),
+        ("data/nested/following.json", json.dumps({"other": "data"})),
+        ("data/foo_following.json", json.dumps({"wrong": "file"})),
+        ("ratings.csv", "Title,Rating\nMovie A,5\nMovie B,3\n"),
+        ("Bookmarks.html", "<html><body><a href='http://example.com'>Example</a></body></html>"),
+        ("post_comments_1.json", json.dumps([{"comment": "one"}])),
+        ("post_comments_2.json", json.dumps([{"comment": "two"}])),
+    )
     members = [
         "data/following.json", "data/nested/following.json",
         "data/foo_following.json", "ratings.csv", "Bookmarks.html",
         "post_comments_1.json", "post_comments_2.json",
     ]
-    return str(zip_path), members
+    return archive, members
 
 
 class TestResolveMember:
     def test_exact_match(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         assert reader.resolve_member("data/following.json") == "data/following.json"
 
     def test_suffix_match_unique(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         assert reader.resolve_member("ratings.csv") == "ratings.csv"
 
     def test_suffix_match_path_boundary(self, sample_zip):
         """foo_following.json must NOT match following.json."""
-        path, members = sample_zip
+        archive, members = sample_zip
         filtered = [m for m in members if m != "data/nested/following.json"]
-        reader = ZipArchiveReader(path, filtered, Counter())
+        reader = ZipArchiveReader(archive, filtered, Counter())
         result = reader.resolve_member("following.json")
         assert result == "data/following.json"
 
     def test_no_match_returns_none(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         assert reader.resolve_member("nonexistent.json") is None
 
     def test_ambiguous_match_returns_none_and_counts_error(self, sample_zip):
         """Multiple path-boundary matches → None + AmbiguousMemberMatch."""
-        path, members = sample_zip
+        archive, members = sample_zip
         errors = Counter()
-        reader = ZipArchiveReader(path, members, errors)
+        reader = ZipArchiveReader(archive, members, errors)
         result = reader.resolve_member("following.json")
         assert result is None
         assert errors["AmbiguousMemberMatch"] == 1
 
-    def test_exact_match_wins_over_suffix(self, tmp_path):
+    def test_exact_match_wins_over_suffix(self):
         """When a file exists at top level AND nested, exact match wins."""
-        zip_path = tmp_path / "test.zip"
-        with zipfile.ZipFile(zip_path, "w") as zf:
-            zf.writestr("ratings.csv", "a,b\n1,2\n")
-            zf.writestr("data/ratings.csv", "c,d\n3,4\n")
+        archive = _build_archive(
+            ("ratings.csv", "a,b\n1,2\n"),
+            ("data/ratings.csv", "c,d\n3,4\n"),
+        )
         members = ["ratings.csv", "data/ratings.csv"]
-        reader = ZipArchiveReader(str(zip_path), members, Counter())
+        reader = ZipArchiveReader(archive, members, Counter())
         assert reader.resolve_member("ratings.csv") == "ratings.csv"
 
 
 class TestJsonExtraction:
     def test_found(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         result = reader.json("data/following.json")
         assert result.found is True
         assert result.data == {"relationships_following": []}
         assert result.member_path == "data/following.json"
 
     def test_not_found(self, sample_zip):
-        path, members = sample_zip
+        archive, members = sample_zip
         errors = Counter()
-        reader = ZipArchiveReader(path, members, errors)
+        reader = ZipArchiveReader(archive, members, errors)
         result = reader.json("nonexistent.json")
         assert result.found is False
         assert result.data == {}
         assert result.member_path is None
         assert errors.get("FileNotFoundInZipError", 0) == 0
 
-    def test_malformed_json(self, tmp_path):
-        zip_path = tmp_path / "bad.zip"
-        with zipfile.ZipFile(zip_path, "w") as zf:
-            zf.writestr("bad.json", "not valid json {{{")
+    def test_malformed_json(self):
+        archive = _build_archive(("bad.json", "not valid json {{{"))
         errors = Counter()
-        reader = ZipArchiveReader(str(zip_path), ["bad.json"], errors)
+        reader = ZipArchiveReader(archive, ["bad.json"], errors)
         result = reader.json("bad.json")
         assert result.found is True
         assert result.data == {}
@@ -115,16 +133,16 @@ class TestJsonExtraction:
 
 class TestCsvExtraction:
     def test_found(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         result = reader.csv("ratings.csv")
         assert result.found is True
         assert isinstance(result.data, pd.DataFrame)
         assert len(result.data) == 2
 
     def test_not_found(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         result = reader.csv("nonexistent.csv")
         assert result.found is False
         assert result.data.empty
@@ -132,15 +150,15 @@ class TestCsvExtraction:
 
 class TestRawExtraction:
     def test_found(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         result = reader.raw("Bookmarks.html")
         assert result.found is True
         assert b"Example" in result.data.getvalue()
 
     def test_not_found(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         result = reader.raw("nonexistent.html")
         assert result.found is False
         assert result.data.getvalue() == b""
@@ -148,63 +166,34 @@ class TestRawExtraction:
 
 class TestJsonAll:
     def test_matches_multiple(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         results = reader.json_all(r"post_comments_\d+\.json$")
         assert len(results) == 2
         assert all(r.found for r in results)
 
     def test_sorted_lexicographically(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         results = reader.json_all(r"post_comments_\d+\.json$")
         paths = [r.member_path for r in results]
         assert paths == sorted(paths)
 
     def test_no_matches(self, sample_zip):
-        path, members = sample_zip
-        reader = ZipArchiveReader(path, members, Counter())
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         results = reader.json_all(r"nonexistent_\d+\.json$")
         assert results == []
 
 
-class TestFileLikeAcceptance:
-    """ZipArchiveReader must accept a seekable binary file-like archive
-    (e.g. AsyncFileAdapter), not just a path string. AD0007.
+class TestMultipleReads:
+    """Successive ZipFile contexts on the same archive object work
+    (mirrors AsyncFileAdapter reuse across member accesses).
     """
 
-    @pytest.fixture
-    def sample_archive_buf(self):
-        """Build the same archive as `sample_zip` but as a BytesIO buffer."""
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, "w") as zf:
-            zf.writestr("data/following.json", json.dumps({"relationships_following": []}))
-            zf.writestr("ratings.csv", "Title,Rating\nMovie A,5\nMovie B,3\n")
-        members = ["data/following.json", "ratings.csv"]
-        return buf, members
-
-    def test_json_extraction_from_bytesio(self, sample_archive_buf):
-        """Reader extracts JSON from a BytesIO-backed archive."""
-        buf, members = sample_archive_buf
-        reader = ZipArchiveReader(buf, members, Counter())
-        result = reader.json("data/following.json")
-        assert result.found is True
-        assert result.data == {"relationships_following": []}
-
-    def test_csv_extraction_from_bytesio(self, sample_archive_buf):
-        """Reader extracts CSV from a BytesIO-backed archive."""
-        buf, members = sample_archive_buf
-        reader = ZipArchiveReader(buf, members, Counter())
-        result = reader.csv("ratings.csv")
-        assert result.found is True
-        assert len(result.data) == 2
-
-    def test_multiple_reads_from_same_bytesio(self, sample_archive_buf):
-        """Successive ZipFile contexts on the same archive object work
-        (mirrors AsyncFileAdapter reuse across member accesses).
-        """
-        buf, members = sample_archive_buf
-        reader = ZipArchiveReader(buf, members, Counter())
+    def test_multiple_reads_from_same_archive(self, sample_zip):
+        archive, members = sample_zip
+        reader = ZipArchiveReader(archive, members, Counter())
         r1 = reader.json("data/following.json")
         r2 = reader.csv("ratings.csv")
         assert r1.found and r2.found


### PR DESCRIPTION
Define SeekableBinaryReader Protocol (read|seek|tell) and narrow the upload-path consumers (validate.validate_zip, ZipArchiveReader) to accept only this Protocol, with path strings no longer accepted. Renames the path_to_zip/zip_path parameters and the ZipArchiveReader.zip_path attribute to 'archive' for consistency.

Type narrowing makes the streaming invariant from extraction/AD0007 checkable at the typecheck layer (Pyright via 'pnpm typecheck:py'). CI doesn't currently run typecheck, so this is local code-review aid rather than a CI gate. If we combine it with the absence of materialize_file(), it's probably sufficient.

Tests are refactored to ues io.BytesIO fixrues instead of tmp_path string fixtures.