### PR TITLE
Small UI improvements for mobile devices

### DIFF
--- a/packages/data-collector/index.html
+++ b/packages/data-collector/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Feldspar Demo</title>
     <style>
-      body { padding: 2rem; }
+      body { padding: 2rem; @media (max-width: 800px) {padding: 0.5rem;}}
     </style>
   </head>
   <body>

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/figure.tsx
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/figure.tsx
@@ -118,7 +118,7 @@ export const FigureComponent = ({
         <div className='flex flex-col '>
           <div
             // ref={ref}
-            className='grid relative z-50 w-full pr-1  min-w-[500px]'
+            className='grid relative z-50 w-full pr-1  min-w-[250px]'
             style={{ gridTemplateRows: String(height) + 'px' }}
           >
             <RenderVisualization


### PR DESCRIPTION
1. Reduced root padding for screen widths < 800px to fit more content on the screen:

<img width="410" height="698" alt="Screenshot from 2026-06-05 15-24-43" src="https://github.com/user-attachments/assets/8a7c6106-bd34-4db5-a60f-9b7705c768a4" />
<img width="410" height="698" alt="Screenshot from 2026-06-05 16-09-57" src="https://github.com/user-attachments/assets/f46ab031-8ed6-4f9b-8cc4-cfe71a773baa" />


2. Reduced minimum image container size to prevent horizontal scrolling on phones:

<img width="410" height="698" alt="Screenshot from 2026-06-05 15-27-15" src="https://github.com/user-attachments/assets/58791f1d-5f18-4299-b37b-ab4996f5bc25" />
<img width="410" height="698" alt="Screenshot from 2026-06-05 17-05-30" src="https://github.com/user-attachments/assets/0ab7e3b0-1985-46ee-8450-dccaa2377b6e" />
