### PR TITLE
Fix PrimaryButton collapsing instead of showing spinner, closes #60

### DIFF
--- a/packages/feldspar/src/framework/visualization/react/ui/elements/button.tsx
+++ b/packages/feldspar/src/framework/visualization/react/ui/elements/button.tsx
@@ -19,11 +19,15 @@ export const PrimaryButton = ({ label, spinning = false, enabled = true, color =
   return (
     <div role="button" className='relative'>
       <div className={`flex flex-col items-center leading-none font-button text-button rounded ${enabled ? 'cursor-pointer active:shadow-top4px' : ''} ${color}`} onClick={onClick}>
-        <div id='confirm-button' className={`pt-15px pb-15px pr-4 pl-4 ${enabled ? 'active:pt-4 active:pb-14px' : ''} ${spinning ? 'hidden' : ''}`}>
+        {/* While spinning, keep the label with `opacity-0` (not `hidden`) so the
+            button retains its size, and overlay the spinner with `absolute`. Using
+            `hidden` collapses the button and the spinner has nothing to cover — see
+            issue #60 / commit e628943. */}
+        <div id='confirm-button' className={`pt-15px pb-15px pr-4 pl-4 ${enabled ? 'active:pt-4 active:pb-14px' : ''} ${spinning ? 'opacity-0' : ''}`}>
           {label}
         </div>
       </div>
-      <div className={`h-full w-full flex flex-col justify-center items-center ${spinning ? '' : 'hidden'}`}>
+      <div className={`absolute top-0 h-full w-full flex flex-col justify-center items-center ${spinning ? '' : 'hidden'}`}>
         <Spinner color={spinnerColor(color)} spinning={spinning} />
       </div>
     </div>


### PR DESCRIPTION
The original change in Feldspar was meant to center the element on the button, which it achieved, but in simplifying the button commit `e628943` changed feldspar's PrimaryButton's spinning label and spinner overlay. 

The change made is so that while spinning the label collapsed the button's box. The spinner div didn't have anything to overlay and vanishes. This reversion keeps the centering but fixes the collateral damage from the other change. 

So we're reverting only `hidden` -> `opacity-0` and restoring `absolute top-0` on the spinner overlay

I verified it working on Next but can't catch a screenshot because it was too fast. I didn't see any other places where this change might touch, but I guess we should maybe be on the lookout for any other buttons that might possibly behave differently. 