### PR TITLE
Fix/viz worker memory

### DIFF
--- a/docs/decisions/0016-prefer-standard-feldspar-prompts-custom-only-when-needed.md
+++ b/docs/decisions/0016-prefer-standard-feldspar-prompts-custom-only-when-needed.md
@@ -22,4 +22,8 @@ Prefer standard feldspar prompt components (`PropsUIPromptConfirm`, `PropsUIProm
 
 - Reach for a standard feldspar prompt first — it works on any feldspar host with no custom factory and inherits upstream improvements.
 - Add a D3I custom prompt only when the UX genuinely can't be met by a standard one; a custom prompt needs a factory registered in data-collector and carries maintenance and bug risk (e.g. the single-button `PropsUIPromptRetry` defect, exposed once FlowBuilder actually checked the retry response).
-- This record is `proposed`, not yet settled — the standing question is where exactly to draw the standard-vs-custom line for flow-control prompts (the hybrid option: standard for flow control, custom for data display).
+- This record is `proposed`, not yet settled — the standing question is where exactly to draw the standard-vs-custom line for flow-control prompts (the hybrid option: standard for flow control, custom for data display); the consent-viz donate-flow record scoped to `consent_form_viz.tsx` settles the memory half of that question for large tables.
+
+## Why
+
+Standard prompts inherit upstream fixes and host compatibility for free; every custom prompt is a standing maintenance liability that only pays for itself when the UX demands it.

--- a/docs/decisions/0031-consent-page-memory-work-must-never-shrink-the-donated-dataset.md
+++ b/docs/decisions/0031-consent-page-memory-work-must-never-shrink-the-donated-dataset.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: proposed
 date: "2026-07-16"
 category: Data collector
 applies_to:
@@ -19,6 +19,7 @@ Memory and display optimizations on the consent-viz page must never reduce the d
 - When cutting consent-page memory, trim only transient copies (worker messages via `selectVisualizationColumns`, display windows) — `serializeConsentData()` must keep serializing every non-deleted row of every table.
 - Review rejects any row cap (e.g. a `MAX_ROWS`-style bound) applied to the `tables` state, `originalBody`, or the serialized payload; display pagination over the full data is the fix path.
 - Participant-initiated deletion (delete/undo in `table_container.tsx`) is the only legitimate dataset reduction.
+- This record is `proposed` — team agreement on the invariant (and on whether any display-side bound may ever interact with the donated payload) is still pending.
 
 ## Why
 

--- a/docs/decisions/0031-consent-page-memory-work-must-never-shrink-the-donated-dataset.md
+++ b/docs/decisions/0031-consent-page-memory-work-must-never-shrink-the-donated-dataset.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+date: "2026-07-16"
+category: Data collector
+applies_to:
+    - packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx
+    - packages/data-collector/src/components/consent_form_viz/table_container.tsx
+priority: invariant
+---
+
+# Consent-page memory work must never shrink the donated dataset
+
+## Decision
+
+Memory and display optimizations on the consent-viz page must never reduce the donated dataset: the payload built by `serializeConsentData()` is exactly the parsed tables minus the participant's own explicit deletions. Any future row truncation must be display-only.
+
+## Guidance
+
+- When cutting consent-page memory, trim only transient copies (worker messages via `selectVisualizationColumns`, display windows) — `serializeConsentData()` must keep serializing every non-deleted row of every table.
+- Review rejects any row cap (e.g. a `MAX_ROWS`-style bound) applied to the `tables` state, `originalBody`, or the serialized payload; display pagination over the full data is the fix path.
+- Participant-initiated deletion (delete/undo in `table_container.tsx`) is the only legitimate dataset reduction.
+
+## Why
+
+A silent cap turns "donate your data" into "donate a sample" without the participant or researcher knowing — it corrupts research-data integrity to save memory (issue #122 advisor review).

--- a/docs/decisions/0032-visualization-workers-are-ephemeral-and-column-scoped.md
+++ b/docs/decisions/0032-visualization-workers-are-ephemeral-and-column-scoped.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+date: "2026-07-16"
+category: Data collector
+applies_to:
+    - packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/useVisualizationData.tsx
+    - packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.ts
+    - packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/visualizationDataWorker.ts
+priority: default
+companions:
+    - packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.test.ts
+---
+
+# Visualization workers are ephemeral and column-scoped
+
+## Decision
+
+Each visualization computation runs in a fresh Web Worker that receives only the columns the visualization reads and is terminated as soon as it answers. No persistent workers, no full-table postMessage.
+
+## Guidance
+
+- Post to a visualization worker only a table projected with `selectVisualizationColumns(table, visualization)`, and call `worker.terminate()` both in the message handler and in the effect cleanup — never keep a worker (and its structured-clone payload) alive across computations.
+- A new visualization type must declare the columns it reads in `selectVisualizationColumns` (with a case in its test) before the worker can compute it.
+- Review rejects module-scope or state-held workers, and any postMessage of an unprojected table.
+
+## Why
+
+postMessage structured-clones its payload into renderer memory; persistent full-table workers put 65k-row consent pages ~300 MB over the iOS-class kill threshold (issue #122; A/B benchmark 2026-07-16: peak renderer 1333 MB -> 1029 MB after this rule).

--- a/docs/decisions/0033-consent-viz-donation-must-not-route-through-datasubmissionpage-s-factory-data-path.md
+++ b/docs/decisions/0033-consent-viz-donation-must-not-route-through-datasubmissionpage-s-factory-data-path.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+date: "2026-07-16"
+category: Data collector
+applies_to:
+    - packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx
+priority: default
+---
+
+# Consent-viz donation must not route through DataSubmissionPage's factory data path
+
+## Decision
+
+The consent-viz prompt consumes shared feldspar components such as `DonateButtons` by direct import (via the D3I exports block in feldspar's `index.ts`) and resolves its own donation payload. It must not report table data through `DataSubmissionPage`'s `onDataSubmissionDataChanged`/`DonateButtonsFactory` path.
+
+## Guidance
+
+- Wire donate/cancel by passing `handleDonate`/`handleCancel` into a directly imported `DonateButtons` — do not route table data through `DataSubmissionPage`'s `onDataSubmissionDataChanged`/`DonateButtonsFactory` path; the component builds its own `PayloadJSON` from `serializeConsentData()` at click time.
+- Review rejects pushing serialized consent tables into `onDataSubmissionDataChanged` or composing the consent-viz page from a separate `PropsUIDataSubmissionButtons` body item, until upstream stops holding a page-lifetime payload copy and double-stringifying at donate.
+- Revisit if upstream `data_submission_page.tsx` moves to lazy pull-at-donate and drops its payload `console.log`s (tracked in UPSTREAM_REQUESTS).
+
+## Why
+
+The factory path holds a serialized copy of all table data for the page lifetime and stacks `Object.fromEntries`/`JSON.stringify` copies (plus a log-only stringify) at donate-click — measured +314 MB donate spike on the 65k-row reference DDP (2026-07-16), squarely in the iOS kill zone.

--- a/docs/decisions/0033-consent-viz-donation-must-not-route-through-datasubmissionpage-s-factory-data-path.md
+++ b/docs/decisions/0033-consent-viz-donation-must-not-route-through-datasubmissionpage-s-factory-data-path.md
@@ -21,4 +21,4 @@ The consent-viz prompt consumes shared feldspar components such as `DonateButton
 
 ## Why
 
-The factory path holds a serialized copy of all table data for the page lifetime and stacks `Object.fromEntries`/`JSON.stringify` copies (plus a log-only stringify) at donate-click — measured +314 MB donate spike on the 65k-row reference DDP (2026-07-16), squarely in the iOS kill zone.
+The factory path holds a serialized copy of all table data for the page lifetime and stacks `Object.fromEntries`/`JSON.stringify` copies (plus a log-only stringify) at donate-click — code-verified in `data_submission_page.tsx`; the path itself was never benchmarked. The donate click is empirically the flow's peak-memory moment (the 2026-07-16 baseline measured a +314 MB spike there on the then-current direct path, development build), and the factory path would stack its additional payload-sized copies at exactly that moment — squarely in the iOS kill zone.

--- a/docs/decisions/0034-hold-participant-flow-peak-memory-to-the-824-mb-reference-budget.md
+++ b/docs/decisions/0034-hold-participant-flow-peak-memory-to-the-824-mb-reference-budget.md
@@ -1,0 +1,25 @@
+---
+status: proposed
+date: "2026-07-17"
+category: Performance
+applies_to:
+    - packages/data-collector/src/components/consent_form_viz/**
+    - scripts/benchmarks/memtest-v3-peak.cjs
+priority: default
+---
+
+# Hold participant-flow peak memory to the ~824 MB reference budget
+
+## Decision
+
+Peak instantaneous renderer RSS across the participant flow (upload → consent → donate) on the 65k-row reference DDP must not exceed ~824 MB in a production-representative build. This record is the budget, not a claim of compliance: as of 2026-07-16 the flow measures above it (989–1029 MB, development-build A/B after the ephemeral-worker fix).
+
+## Guidance
+
+- Before merging memory-relevant changes to the consent/viz flow, run `scripts/benchmarks/memtest-v3-peak.cjs` (donate phase included) on the reference DDP and compare per-phase peaks against the budget; deltas over each run's own idle baseline are the comparable A/B metric.
+- Absolute numbers count only from a production-representative build with a non-logging data-submission sink — `NODE_ENV=development` builds run FakeBridge (which logs the full donation) and StrictMode React, inflating every phase; treat those runs as relative evidence only.
+- Track `peakTreeMb` alongside renderer RSS (Pyodide's worker heap lives in the same process tree), and treat real iOS hardware/WebKit as the final authority for the absolute gate.
+
+## Why
+
+iOS WebKit kills pages on instantaneous footprint in roughly the 1–1.5 GB band; ~824 MB (the reference flow's upload-phase peak) leaves headroom on smaller devices — the budget is the difference between a completed donation and a participant losing their work mid-flow.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -58,3 +58,7 @@ Load the ADR(s) whose filename matches the area you are touching.
 - [0031 — Consent-page memory work must never shrink the donated dataset](./0031-consent-page-memory-work-must-never-shrink-the-donated-dataset.md)
 - [0032 — Visualization workers are ephemeral and column-scoped](./0032-visualization-workers-are-ephemeral-and-column-scoped.md)
 - [0033 — Consent-viz donation must not route through DataSubmissionPage's factory data path](./0033-consent-viz-donation-must-not-route-through-datasubmissionpage-s-factory-data-path.md)
+
+### Performance
+
+- [0034 — Hold participant-flow peak memory to the ~824 MB reference budget](./0034-hold-participant-flow-peak-memory-to-the-824-mb-reference-budget.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -55,3 +55,6 @@ Load the ADR(s) whose filename matches the area you are touching.
 ### Data collector
 
 - [0016 — Prefer standard feldspar prompts; custom only when needed](./0016-prefer-standard-feldspar-prompts-custom-only-when-needed.md)
+- [0031 — Consent-page memory work must never shrink the donated dataset](./0031-consent-page-memory-work-must-never-shrink-the-donated-dataset.md)
+- [0032 — Visualization workers are ephemeral and column-scoped](./0032-visualization-workers-are-ephemeral-and-column-scoped.md)
+- [0033 — Consent-viz donation must not route through DataSubmissionPage's factory data path](./0033-consent-viz-donation-must-not-route-through-datasubmissionpage-s-factory-data-path.md)

--- a/docs/superpowers/plans/2026-07-16-viz-worker-memory.md
+++ b/docs/superpowers/plans/2026-07-16-viz-worker-memory.md
@@ -1,0 +1,624 @@
+# Viz-Worker Memory Fix (Issue #122) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut consent-page peak renderer memory by sending only viz-relevant columns to visualization workers, terminating each worker after it computes, and removing the double table parse in `consent_form_viz.tsx`; while touching the file, adopt the Milestone-8 `DonateButtons` component in place of the hand-rolled donate/cancel block.
+
+**Provenance (verified 2026-07-16):** The entire `consent_form_viz/` tree (component, visualization_plugin, worker) is D3I-custom — upstream `eyra/feldspar` has no counterpart anywhere (added by D3I commit `3b884df`, "developed by @kasperwelbers"). Tasks 1–3 touch no shared upstream surface. Task 4 touches `packages/feldspar/src/index.ts`, which already diverges via a D3I exports block (being renamed from "EXPORTS ADDED BY NdS" in the same step); the addition is one line in that block. Our `button.tsx` deliberately diverges from upstream (PR #78 spinner-collapse fix) but has an identical props API, so `DonateButtons` (byte-identical to upstream in our tree) composes correctly with it.
+
+**Architecture:** All changes are inside `packages/data-collector/src/components/consent_form_viz/`. A new pure function `selectVisualizationColumns(table, visualization)` projects a `Table` down to the columns a visualization actually reads (the worker resolves columns by name via `getTableColumn`, so projection is transparent to it). `useVisualizationData` is restructured from one persistent worker per figure to an ephemeral worker per computation — spawned in the `[table, visualization]` effect, terminated on result and in effect cleanup. The double parse is fixed with a skip-first-render ref. **No donated data is truncated or dropped** — projection affects only what crosses `postMessage` into the worker; React state, the table UI, and the donation payload are untouched (issue #122 advisor review: display-side changes must never shrink the donated dataset).
+
+**Tech Stack:** TypeScript/React 19 (Vite), Web Workers, zod (existing types), jest + ts-jest (new to `@eyra/data-collector`, mirroring `@eyra/feldspar`), Playwright e2e, memory benchmark harnesses in `scripts/benchmarks/`.
+
+## Global Constraints
+
+- **Never truncate or mutate donated data** — projection is for the worker message only (issue #122).
+- **No real participant DDPs in version control** (ADR-0014) — the reference DDP stays a local file referenced via `MEMTEST_ZIP`.
+- **ADR-0016** (prefer standard feldspar prompts) — satisfied: we modify the existing custom consent-viz prompt, no new custom prompt.
+- **Claude never runs `git commit` or `git push`** — each commit step stages files and hands the exact command to Danielle.
+- **Branch:** `fix/viz-worker-memory` off `development`, landed via PR to `d3i-infra/data-donation-task`. Use a worktree (superpowers:using-git-worktrees) at execution time.
+- **Acceptance:** peak renderer RSS ≤ ~824 MB on the 65k-row reference DDP, measured with `MEMTEST_ZIP=<local ddp> node scripts/benchmarks/memtest-v3-peak.cjs` (methodology: `scripts/benchmarks/README.md`). The harness gains a `donate` phase (Task 5) so the donate-click serialization spike — the moment iOS memory kills are most likely — is measured, not assumed; A/B numbers must include it.
+- **Button-pattern memory verdict (code-verified, to be confirmed by the donate-phase numbers):** direct import of `DonateButtons` is allocation-identical to the current hand-rolled block (one transient `serializeConsentData()` stringify at click). The factory route via M8's `DataSubmissionPage` is memory-negative as shipped: it (a) holds a serialized copy of all table data in a page-lifetime ref (`DataSubmissionData`, pushed via `onDataSubmissionDataChanged` on mount and every edit), (b) stacks `Object.fromEntries` + `JSON.stringify` copies on top of that at donate click, and (c) does an extra payload-sized `JSON.stringify` purely for `console.log` at `data_submission_page.tsx:23,29`. Do not adopt the factory route for large tables until those upstream behaviors change (tracked in Task 7).
+- **After editing:** run `adg lean index --model docs/decisions --root .` (validates the decision model; silent-on-success).
+
+---
+
+### Task 1: `selectVisualizationColumns` — pure column projection (+ jest infra for data-collector)
+
+**Files:**
+- Modify: `packages/data-collector/package.json` (add jest devDeps + test script)
+- Create: `packages/data-collector/jest.config.js`
+- Create: `packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.ts`
+- Test: `packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.test.ts`
+
+**Interfaces:**
+- Consumes: `Table`, `VisualizationType`, `ChartVisualization`, `TextVisualization` from `../types` (existing zod-derived types).
+- Produces: `selectVisualizationColumns(table: Table, visualization: VisualizationType): Table` — later tasks import it by this exact name.
+
+- [ ] **Step 1: Add jest infrastructure (mirrors `packages/feldspar`)**
+
+In `packages/data-collector/package.json`, change the test script and add devDependencies (versions copied from `packages/feldspar/package.json`):
+
+```jsonc
+// scripts:
+"test": "jest",
+// devDependencies (add):
+"@types/jest": "30.0.0",
+"jest": "30.4.2",
+"ts-jest": "29.4.11",
+```
+
+Create `packages/data-collector/jest.config.js` (identical to feldspar's):
+
+```js
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      useESM: true,
+    }],
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+};
+```
+
+Run: `pnpm install`
+Expected: lockfile updated, deps installed.
+
+- [ ] **Step 2: Write the failing test**
+
+`selectVisualizationColumns.test.ts`:
+
+```ts
+import { selectVisualizationColumns } from './selectVisualizationColumns'
+import { Table, VisualizationType } from '../types'
+
+function makeTable (): Table {
+  return {
+    id: 'tiktok_videos',
+    head: { cells: ['date', 'title', 'url', 'duration', 'category'] },
+    body: {
+      rows: [
+        { id: 'r1', cells: ['2024-01-01', 'video one', 'https://a.example', '10', 'music'] },
+        { id: 'r2', cells: ['2024-01-02', 'video two', 'https://b.example', '20', 'sports'] }
+      ]
+    }
+  }
+}
+
+describe('selectVisualizationColumns', () => {
+  it('keeps only the columns a chart visualization reads', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'per day' },
+      type: 'line',
+      group: { column: 'date' },
+      values: [{ column: 'duration', aggregate: 'sum', group_by: 'category' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['date', 'duration', 'category'])
+    expect(projected.body.rows).toEqual([
+      { id: 'r1', cells: ['2024-01-01', '10', 'music'] },
+      { id: 'r2', cells: ['2024-01-02', '20', 'sports'] }
+    ])
+    expect(projected.id).toBe('tiktok_videos')
+  })
+
+  it('does not materialize the .COUNT pseudo-column', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'count per day' },
+      type: 'bar',
+      group: { column: 'date' },
+      values: [{ column: '.COUNT' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['date'])
+  })
+
+  it('keeps textColumn and valueColumn for a wordcloud', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'words' },
+      type: 'wordcloud',
+      textColumn: 'title',
+      valueColumn: 'duration'
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['title', 'duration'])
+    expect(projected.body.rows[0].cells).toEqual(['video one', '10'])
+  })
+
+  it('drops referenced columns that do not exist in the table (worker reports the error)', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'bad' },
+      type: 'bar',
+      group: { column: 'no_such_column' },
+      values: [{ column: 'duration' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['duration'])
+  })
+
+  it('preserves row ids so rowId-based deletion still works', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'per day' },
+      type: 'area',
+      group: { column: 'date' },
+      values: [{ column: 'duration' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.body.rows.map((r) => r.id)).toEqual(['r1', 'r2'])
+  })
+})
+```
+
+Note: `zAggregationValue.column` has a zod default of `.COUNT`, but these tests construct plain TS objects (no zod parse), so `column` is passed explicitly where needed.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @eyra/data-collector test`
+Expected: FAIL — `Cannot find module './selectVisualizationColumns'`.
+
+- [ ] **Step 4: Write the implementation**
+
+`selectVisualizationColumns.ts`:
+
+```ts
+import { ChartVisualization, TextVisualization, VisualizationType, Table } from '../types'
+
+/**
+ * Project a table down to only the columns the visualization reads, so that
+ * postMessage structured-clones a fraction of the table into the worker
+ * (issue #122). The worker resolves columns by name (getTableColumn), so the
+ * projection is transparent to it. Display and donation data are unaffected.
+ */
+export function selectVisualizationColumns (table: Table, visualization: VisualizationType): Table {
+  const columns = visualizationColumns(visualization).filter((column) => table.head.cells.includes(column))
+  const indices = columns.map((column) => table.head.cells.indexOf(column))
+  return {
+    id: table.id,
+    head: { cells: columns },
+    body: {
+      rows: table.body.rows.map((row) => ({
+        id: row.id,
+        cells: indices.map((index) => row.cells[index])
+      }))
+    }
+  }
+}
+
+function visualizationColumns (visualization: VisualizationType): string[] {
+  const columns = new Set<string>()
+
+  if (['line', 'bar', 'area'].includes(visualization.type)) {
+    const chart = visualization as ChartVisualization
+    columns.add(chart.group.column)
+    for (const value of chart.values) {
+      if (value.column !== undefined) columns.add(value.column)
+      if (value.group_by !== undefined) columns.add(value.group_by)
+      if (value.z !== undefined) columns.add(value.z)
+    }
+  }
+
+  if (visualization.type === 'wordcloud') {
+    const text = visualization as TextVisualization
+    columns.add(text.textColumn)
+    if (text.valueColumn !== undefined) columns.add(text.valueColumn)
+  }
+
+  return Array.from(columns)
+}
+```
+
+Rationale notes:
+- `.COUNT` (and any column missing from `head.cells`, e.g. a typo in a viz spec) is filtered out; `getTableColumn` in the worker special-cases `.COUNT` and still throws its existing clear error for genuinely missing columns, so error behavior is unchanged.
+- `value.z` is included defensively — it is in `zAggregationValue` even though `prepareChartData` does not read it today; if it starts being read, projection won't silently starve it.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @eyra/data-collector test`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Stage and hand off commit**
+
+```bash
+git add packages/data-collector/package.json packages/data-collector/jest.config.js pnpm-lock.yaml \
+  packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.ts \
+  packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.test.ts
+```
+
+Hand to Danielle:
+`git commit -m "feat(viz): add selectVisualizationColumns projection + jest infra for data-collector"`
+
+---
+
+### Task 2: Ephemeral, column-scoped workers in `useVisualizationData`
+
+**Files:**
+- Modify: `packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/useVisualizationData.tsx` (full rewrite of the hook body)
+
+**Interfaces:**
+- Consumes: `selectVisualizationColumns(table, visualization): Table` from Task 1.
+- Produces: unchanged hook signature `useVisualizationData(table: Table, visualization: VisualizationType): [VisualizationData | undefined, Status]` — `figure.tsx` needs no changes.
+
+- [ ] **Step 1: Rewrite the hook**
+
+Replace the entire contents of `useVisualizationData.tsx` with:
+
+```tsx
+import { VisualizationType, VisualizationData, Table } from '../types'
+import { useEffect, useState } from 'react'
+import { selectVisualizationColumns } from './selectVisualizationColumns'
+
+type Status = 'loading' | 'success' | 'error'
+
+export default function useVisualizationData (
+  table: Table,
+  visualization: VisualizationType
+): [VisualizationData | undefined, Status] {
+  const [visualizationData, setVisualizationData] = useState<VisualizationData>()
+  const [status, setStatus] = useState<Status>('loading')
+
+  useEffect(() => {
+    if (window.Worker === undefined) {
+      setStatus('error')
+      return
+    }
+    setStatus('loading')
+    // Spawn a worker per computation and terminate it as soon as it answers,
+    // instead of keeping a persistent worker holding a clone of the table
+    // alive for the lifetime of the figure (issue #122).
+    const worker = new Worker(
+      new URL('./visualizationDataWorker.ts', import.meta.url), { type: 'module' })
+    worker.onmessage = (e: MessageEvent<{ status: Status, visualizationData: VisualizationData }>) => {
+      setVisualizationData(e.data.visualizationData)
+      setStatus(e.data.status)
+      worker.terminate()
+    }
+    worker.postMessage({ table: selectVisualizationColumns(table, visualization), visualization })
+    return () => {
+      worker.terminate()
+    }
+  }, [table, visualization])
+
+  return [visualizationData, status]
+}
+```
+
+Behavior notes (verify while implementing):
+- The cleanup `worker.terminate()` also kills stale in-flight computations when `table` changes (row delete/undo, search filter), eliminating the previous stale-response window. Terminating an already-terminated worker is a no-op.
+- The old `setWorker` state and the dead `try/catch` around `setState` calls are gone; `window.Worker === undefined` now yields an explicit `'error'` status instead of silently staying `'loading'`.
+
+- [ ] **Step 2: Typecheck/build**
+
+Run: `pnpm build`
+Expected: builds clean (this also type-checks `data-collector` via Vite/tsc).
+
+- [ ] **Step 3: Manual smoke via dev server**
+
+Run: `VITE_PLATFORM=tiktok BROWSER=none pnpm start`, load `http://localhost:3000`, drive a small test zip (`tests/test.zip`) to the consent page.
+Expected: charts and wordclouds render; deleting rows updates figures; DevTools → Sources shows no lingering `visualizationDataWorker` threads after figures settle.
+
+- [ ] **Step 4: Stage and hand off commit**
+
+```bash
+git add packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/useVisualizationData.tsx
+```
+
+Hand to Danielle:
+`git commit -m "fix(viz): project columns before postMessage and terminate workers after computing (#122)"`
+
+---
+
+### Task 3: Fix the double parse in `consent_form_viz.tsx`
+
+**Files:**
+- Modify: `packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx:19,26-33`
+
+**Interfaces:**
+- Consumes: nothing from other tasks (independent).
+- Produces: no API change.
+
+- [ ] **Step 1: Skip the mount-time re-parse**
+
+The lazy `useState` initializer (line 26) already parses `props.tables`; the `[props.tables]` effect (lines 31–33) re-parses the same value on mount. Keep the effect for genuine prop changes, skip its first run:
+
+Change the react import (line 19):
+
+```tsx
+import { useCallback, useEffect, useRef, useState } from "react"
+```
+
+Replace lines 26–33:
+
+```tsx
+export const ConsentFormViz = (props: Props): JSX.Element => {
+  const [tables, setTables] = useState<TableWithContext[]>(() => parseTables(props.tables))
+  const { locale, resolve } = props
+  const { description, donateQuestion, donateButton, cancelButton } = prepareCopy(props)
+  const [isDonating, setIsDonating] = useState(false)
+  // The state initializer above already parsed props.tables; only re-parse
+  // when the host actually sends new tables (issue #122 double parse).
+  // Previous-value comparison rather than a boolean flag: a flag with no
+  // cleanup reset is defeated by StrictMode's dev double-invocation.
+  const parsedTables = useRef(props.tables)
+
+  useEffect(() => {
+    if (parsedTables.current === props.tables) return
+    parsedTables.current = props.tables
+    setTables(parseTables(props.tables))
+  }, [props.tables])
+```
+
+(Only the `parsedTables` ref and the effect guard are new; the surrounding lines are shown for placement.)
+
+- [ ] **Step 2: Typecheck/build**
+
+Run: `pnpm build`
+Expected: clean.
+
+- [ ] **Step 3: Stage and hand off commit**
+
+```bash
+git add packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx
+```
+
+Hand to Danielle:
+`git commit -m "fix(viz): parse consent tables once on mount, not twice (#122)"`
+
+---
+
+### Task 4: Adopt `DonateButtons` (direct import) in `consent_form_viz.tsx`
+
+Memory-neutral by construction (see Global Constraints); gains the M8 waiting behavior ("Transferring data… Please keep this window open."), deletes the hand-rolled duplicate of `donate_buttons.tsx`, and keeps D3I default copy by passing our existing bundles as props. Note `generate_review_data_prompt` (Python) always sets `donate_question`/`donate_button` explicitly, so the component defaults are a fallback only.
+
+**Files:**
+- Modify: `packages/feldspar/src/index.ts` (one line in the existing "EXPORTS ADDED BY NdS" block)
+- Modify: `packages/data-collector/src/components/consent_form_viz/types.ts` (fix the latent `Text` type bug)
+- Modify: `packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx`
+
+**Interfaces:**
+- Consumes: `DonateButtons({ onDonate, onCancel, locale, donateQuestion?, donateButton? })` from feldspar prompts (identical to upstream).
+- Produces: no API change; donation payload format unchanged (`PayloadJSON` of the serialized tables array).
+
+- [ ] **Step 1: Export DonateButtons from feldspar; rename the divergence marker**
+
+In `packages/feldspar/src/index.ts`, rename the block comment `// EXPORTS ADDED BY NdS` to:
+
+```ts
+// D3I additions to the upstream feldspar exports
+```
+
+and add to that block:
+
+```ts
+export { DonateButtons } from './framework/visualization/react/ui/prompts/donate_buttons'
+```
+
+- [ ] **Step 2: Fix the latent `Text` type**
+
+`consent_form_viz/types.ts` uses `Text` without defining or importing it — today it silently resolves to the **DOM global `Text`** node type. Passing `props.donateQuestion` to `DonateButtons` (which expects feldspar's `Text = Translatable | string`) surfaces this. Add at the top of `types.ts`, following the plugin's type-duplication convention (see `visualization_plugin/types.ts` header comment):
+
+```ts
+// Matching feldspar's Text/Translatable (duplicated like visualization_plugin/types.ts
+// to keep the plugin self-contained). Previously `Text` silently resolved to the DOM
+// global Text node type.
+export interface Translatable {
+  translations: { [locale: string]: string }
+}
+export type Text = Translatable | string
+```
+
+If `pnpm build` then flags `Translator.translate` call sites, resolve per-site with the real type (do not cast to `any`).
+
+- [ ] **Step 3: Replace the hand-rolled button block**
+
+In `consent_form_viz.tsx`:
+
+Imports — drop `LabelButton`/`PrimaryButton`, add `DonateButtons`:
+
+```tsx
+import {
+  DonateButtons,
+  BodyLarge,
+  Translator,
+  ReactFactoryContext,
+} from "@eyra/feldspar"
+```
+
+Remove the `isDonating` state (line 29) and simplify `handleDonate`:
+
+```tsx
+  function handleDonate(): void {
+    const value = serializeConsentData()
+    resolve?.({ __type__: "PayloadJSON", "value": value })
+  }
+```
+
+Shrink `prepareCopy`/`Copy` to `description` only (DonateButtons owns question/button/cancel copy):
+
+```tsx
+interface Copy {
+  description: string
+}
+
+function prepareCopy({ description, locale }: Props): Copy {
+  return {
+    description: Translator.translate(description ?? defaultDescription, locale),
+  }
+}
+```
+
+and destructure only `const { description } = prepareCopy(props)`.
+
+Replace the question + buttons block (previously lines 174–186) with:
+
+```tsx
+        <DonateButtons
+          onDonate={handleDonate}
+          onCancel={handleCancel}
+          locale={locale}
+          donateQuestion={props.donateQuestion ?? defaultDonateQuestionLabel}
+          donateButton={props.donateButton ?? defaultDonateButtonLabel}
+        />
+```
+
+Delete `defaultCancelButtonLabel` and `defaultDonateQuestionLabel`/`defaultDonateButtonLabel`? **No** — delete only `defaultCancelButtonLabel` (cancel copy now comes from DonateButtons); keep the donate bundles so D3I "share for research" wording remains the fallback.
+
+- [ ] **Step 4: Build and smoke**
+
+Run: `pnpm build`
+Expected: clean. Then dev-server smoke: donate on a small zip shows the spinner **and** the "Transferring data… Please keep this window open." message; cancel resolves false.
+
+- [ ] **Step 5: Stage and hand off commit**
+
+```bash
+git add packages/feldspar/src/index.ts \
+  packages/data-collector/src/components/consent_form_viz/types.ts \
+  packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx
+```
+
+Hand to Danielle:
+`git commit -m "refactor(viz): adopt M8 DonateButtons in consent_form_viz, fix latent Text type"`
+
+---
+
+### Task 5: Add a `donate` phase to `memtest-v3-peak.cjs`
+
+The harness currently stops at `render+settle` — the donate-click serialization spike is unmeasured, yet it is the likeliest iOS kill point and the exact place button-pattern choices differ. The harness already tracks per-phase renderer peaks, so this is additive.
+
+**Files:**
+- Modify: `scripts/benchmarks/memtest-v3-peak.cjs:73-75`
+- Modify: `scripts/benchmarks/README.md` (document the new phase)
+
+**Interfaces:**
+- Consumes: nothing from other tasks (works on both `development` and the fix branch — needed for the A/B baseline).
+- Produces: `rendererPeaksByPhase.donate` in the `RESULT>` JSON.
+
+- [ ] **Step 1: Extend the flow**
+
+Replace lines 73–75 of `memtest-v3-peak.cjs`:
+
+```js
+  phase = 'render+settle';
+  await page.waitForTimeout(12000);
+
+  phase = 'donate';
+  // Label comes from generate_review_data_prompt; adapt alongside the two
+  // heading selectors when targeting a different platform/flow.
+  await page.getByText('Yes, share for research').click();
+  // The serialization spike is synchronous with the click; a fixed settle
+  // captures it without coupling to whatever page the flow shows next.
+  await page.waitForTimeout(8000);
+  clearInterval(sampler);
+```
+
+Also update the header comment (line 2) from `(navigation -> consent page + settle)` to `(navigation -> consent page -> donate + settle)`.
+
+- [ ] **Step 2: Document in the benchmarks README**
+
+In `scripts/benchmarks/README.md`, extend the `memtest-v3-peak.cjs` row / notes: the flow now includes clicking the donate button, and `rendererPeaksByPhase.donate` isolates the donation-serialization spike; the donate-button label selector must be adapted along with the two heading selectors for non-TikTok flows.
+
+- [ ] **Step 3: Verify on a small zip**
+
+Run (against a running build, e.g. dev server): `MEMTEST_ZIP=tests/test.zip node scripts/benchmarks/memtest-v3-peak.cjs`
+Expected: `RESULT>` JSON includes a `donate` key in `rendererPeaksByPhase`.
+
+- [ ] **Step 4: Stage and hand off commit**
+
+```bash
+git add scripts/benchmarks/memtest-v3-peak.cjs scripts/benchmarks/README.md
+```
+
+Hand to Danielle:
+`git commit -m "feat(benchmarks): measure donate-click peak as its own phase in memtest-v3-peak"`
+
+---
+
+### Task 6: Verification — tests, e2e, benchmark A/B, adg index
+
+**Files:**
+- No source changes; produces benchmark evidence for the PR description.
+
+**Interfaces:**
+- Consumes: the completed Tasks 1–5 on the branch.
+- Produces: pass/fail against the #122 acceptance criterion (peak renderer ≤ ~824 MB), including the donate-phase peak, for both `development` and the fix branch.
+
+- [ ] **Step 1: Full test suite**
+
+Run:
+```bash
+pnpm --filter @eyra/data-collector test
+pnpm --filter @eyra/feldspar test
+pnpm test            # python tests
+pnpm typecheck:py
+pnpm build
+pnpm test:e2e        # Playwright donation.spec.ts
+```
+Expected: all pass.
+
+- [ ] **Step 2: Benchmark the branch (needs the local reference DDP from Danielle)**
+
+Per `scripts/benchmarks/README.md` (v3 peak methodology; the harness expects the TikTok flow):
+
+```bash
+VITE_PLATFORM=tiktok NODE_ENV=development pnpm run build
+cd packages/data-collector/dist && python3 -m http.server 3000 &
+cd -
+MEMTEST_ZIP=/path/to/65k-row-reference.zip node scripts/benchmarks/memtest-v3-peak.cjs
+```
+
+Expected: peak renderer RSS ≤ ~824 MB. Also run the same (Task 5-extended) harness on a `development` build — clean-build both artifacts with one toolchain, same Chromium, interleaved runs per README — and report per-phase renderer peaks for both, as deltas over each run's own baseline. The `donate` phase numbers are the evidence for the button-pattern verdict in Global Constraints: direct-import `DonateButtons` must show no donate-phase regression vs `development`.
+
+- [ ] **Step 3: Validate the decision model**
+
+Run: `adg lean index --model docs/decisions --root .`
+Expected: exits clean (silent on success; the 0016 "no Why yet" warning is pre-existing).
+
+- [ ] **Step 4: Stage plan doc; hand off branch**
+
+```bash
+git add docs/superpowers/plans/2026-07-16-viz-worker-memory.md
+```
+
+Hand to Danielle: commit command plus push/PR commands (stating the remote URL, e.g. `https://github.com/d3i-infra/data-donation-task.git`, branch `fix/viz-worker-memory` → base `development`). PR references #122 and includes the benchmark table.
+
+---
+
+### Task 7 (recommended): Record the pattern as a lean ADR; track the factory-route findings
+
+**Files:**
+- Create: `docs/decisions/00XX-*.md` via `adg lean new` (number assigned by the tool)
+- Modify: `/home/dmm/src/d3i/UPSTREAM_REQUESTS.md` (outside this repo — not part of the branch)
+
+**Interfaces:**
+- Consumes: the donate-phase benchmark numbers from Task 6 (cite them in the records).
+- Produces: ADR authored with the write-adr plugin (write-lean-adr skill), never by hand.
+
+- [ ] **Step 1: Author the record**
+
+Use the write-lean-adr skill / `adg lean new`. Substance to capture:
+- **Decision:** Visualization workers are ephemeral and column-scoped — send only the columns a visualization reads, terminate the worker once it answers. Consent-viz consumes `DonateButtons` by direct import, not via the `DataSubmissionPage` factory route.
+- **Invariant:** Display-side memory work must never shrink the donated dataset; any future row truncation must be display-only (issue #122 advisor review).
+- **Why (factory route rejected for now):** M8's `DataSubmissionPage` holds serialized prompt data in a page-lifetime ref, stacks extra full copies at donate click, and stringifies the payload again for `console.log` — measurably hostile to the iOS peak-memory budget on large tables. Also implies breaking changes to the Python page composition and donated payload shape.
+- **applies_to:** `packages/data-collector/src/components/consent_form_viz/**`
+
+- [ ] **Step 2: Track the upstream proposal**
+
+Add an entry to `/home/dmm/src/d3i/UPSTREAM_REQUESTS.md` (per its convention: repo, title, diagnosis, suggested fix, date): `eyra/feldspar` — `DataSubmissionPage` donation flow allocates several payload-sized copies at donate time (`data_submission_page.tsx`: page-lifetime `DataSubmissionData` ref, `Object.fromEntries`+`JSON.stringify` at click, payload-sized `JSON.stringify` inside `console.log` at lines 23/29). Suggested fix: pull prompt data lazily at donate time and drop payload logging. Cite the donate-phase benchmark numbers from Task 6.
+
+- [ ] **Step 3: Re-index and stage**
+
+Run: `adg lean index --model docs/decisions --root .`
+Expected: exits clean. Stage the new record; hand commit command to Danielle.
+
+---
+
+## Self-Review (done at planning time)
+
+- **Spec coverage:** #122's three fix items map to Tasks 1+2 (columns + terminate) and Task 3 (double parse); the acceptance criterion is Task 6 Step 2, now including the donate-click phase added in Task 5. Danielle's follow-ups are covered: provenance (header note), M8 button adoption (Task 4, same PR as agreed), factory-vs-direct memory question (Global Constraints verdict + Task 5/6 measurement + Task 7 tracking), NdS-block rename (Task 4 Step 1). The issue's `truncateRows`/`MAX_ROWS` observation is deliberately out of scope — the advisor-reviewed fix forbids truncating donated data.
+- **Placeholder scan:** all code steps carry full code; commands carry expected output.
+- **Type consistency:** `selectVisualizationColumns(table: Table, visualization: VisualizationType): Table` is the only cross-task interface; Task 2 imports it by that exact name and signature. Task 4's `Text` fix is self-contained in `consent_form_viz/types.ts`.

--- a/packages/data-collector/jest.config.js
+++ b/packages/data-collector/jest.config.js
@@ -1,0 +1,14 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      useESM: true,
+    }],
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+};

--- a/packages/data-collector/package.json
+++ b/packages/data-collector/package.json
@@ -12,6 +12,7 @@
     "react-dom": "19.2.7"
   },
   "devDependencies": {
+    "@types/jest": "30.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.2",
     "@typescript-eslint/eslint-plugin": "^8.59.3",
@@ -23,10 +24,12 @@
     "eslint-plugin-react-hooks": "^7.0.0",
     "eslint-plugin-react-refresh": "^0.5.0",
     "globals": "^17.5.0",
+    "jest": "30.4.2",
     "postcss": "^8.5.10",
     "react-highlight-words": "^0.21.0",
     "recharts": "^2.15.2",
     "tailwindcss": "^4.2.4",
+    "ts-jest": "29.4.11",
     "typescript": "^6.0.0",
     "vite": "^8.0.13",
     "zod": "^3.24.2"
@@ -36,7 +39,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "vite",
-    "test": "echo \"No tests specified\" && exit 0",
+    "test": "jest",
     "clean": "rimraf dist node_modules"
   },
   "browserslist": {

--- a/packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx
+++ b/packages/data-collector/src/components/consent_form_viz/consent_form_viz.tsx
@@ -1,6 +1,5 @@
 import {
-  LabelButton,
-  PrimaryButton,
+  DonateButtons,
   BodyLarge,
   Translator,
   ReactFactoryContext,
@@ -16,7 +15,7 @@ import {
     PropsUIPromptConsentFormTableViz,
     PropsUITableRow,
 } from "./types"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import _ from "lodash"
 import { TableContainer } from "./table_container"
 
@@ -25,10 +24,14 @@ type Props = PropsUIPromptConsentFormViz & ReactFactoryContext
 export const ConsentFormViz = (props: Props): JSX.Element => {
   const [tables, setTables] = useState<TableWithContext[]>(() => parseTables(props.tables))
   const { locale, resolve } = props
-  const { description, donateQuestion, donateButton, cancelButton } = prepareCopy(props)
-  const [isDonating, setIsDonating] = useState(false)
+  const { description } = prepareCopy(props)
+  // The state initializer above already parsed props.tables; only re-parse
+  // when the host actually sends new tables (issue #122 double parse).
+  const parsedTables = useRef(props.tables)
 
   useEffect(() => {
+    if (parsedTables.current === props.tables) return
+    parsedTables.current = props.tables
     setTables(parseTables(props.tables))
   }, [props.tables])
 
@@ -126,7 +129,6 @@ export const ConsentFormViz = (props: Props): JSX.Element => {
   }
 
   function handleDonate(): void {
-    setIsDonating(true)
     const value = serializeConsentData()
     resolve?.({ __type__: "PayloadJSON", "value": value })
   }
@@ -171,19 +173,13 @@ export const ConsentFormViz = (props: Props): JSX.Element => {
             )
           })}
         </div>
-        <div>
-          <BodyLarge margin="" text={donateQuestion} />
-
-          <div className="flex flex-row gap-4 mt-4 mb-4">
-            <PrimaryButton
-              label={donateButton}
-              onClick={handleDonate}
-              color="bg-success text-white"
-              spinning={isDonating}
-            />
-            <LabelButton label={cancelButton} onClick={handleCancel} color="text-grey1" />
-          </div>
-        </div>
+        <DonateButtons
+          onDonate={handleDonate}
+          onCancel={handleCancel}
+          locale={locale}
+          donateQuestion={props.donateQuestion ?? defaultDonateQuestionLabel}
+          donateButton={props.donateButton ?? defaultDonateButtonLabel}
+        />
       </div>
     </>
   )
@@ -191,17 +187,11 @@ export const ConsentFormViz = (props: Props): JSX.Element => {
 
 interface Copy {
   description: string
-  donateQuestion: string
-  donateButton: string
-  cancelButton: string
 }
 
-function prepareCopy({ donateQuestion, donateButton, description, locale }: Props): Copy {
+function prepareCopy({ description, locale }: Props): Copy {
   return {
     description: Translator.translate(description ?? defaultDescription, locale),
-    donateQuestion: Translator.translate(donateQuestion ?? defaultDonateQuestionLabel, locale),
-    donateButton: Translator.translate(donateButton ?? defaultDonateButtonLabel, locale),
-    cancelButton: Translator.translate(defaultCancelButtonLabel, locale),
   }
 }
 
@@ -221,11 +211,6 @@ const defaultDonateButtonLabel = new TextBundle()
   .add('en', 'Yes, share for research')
   .add('de', 'Ja, für Forschung teilen')
   .add('nl', 'Ja, deel voor onderzoek')
-
-const defaultCancelButtonLabel = new TextBundle()
-  .add('en', 'No')
-  .add('de', 'Nein')
-  .add('nl', 'Nee')
 
 const defaultDescription = new TextBundle()
   .add('en', 'Determine whether you would like to share the data below. Carefully check the data and adjust when required. With your contribution, you help the previously described research. Thank you in advance.')

--- a/packages/data-collector/src/components/consent_form_viz/table_container.tsx
+++ b/packages/data-collector/src/components/consent_form_viz/table_container.tsx
@@ -12,6 +12,7 @@ import { TableItems } from "./table_items"
 import { Figure } from "./visualization_plugin/figure"
 import { Table } from "./table"
 import { SearchBar } from "./search_bar"
+import { zTable, Table as ValidatedTable } from "./visualization_plugin/types"
 
 interface TableContainerProps {
   id: string
@@ -45,6 +46,16 @@ export const TableContainer = ({ id, table, updateTable, locale }: TableContaine
     const filteredRows = table.body.rows.filter((row) => searchFilterIds.has(row.id))
     return { ...table, body: { ...table.body, rows: filteredRows } }
   }, [table, searchFilterIds])
+
+  // Validate once per table update and share across figures — previously every
+  // Figure deep-cloned the full table via zod (issue #122). Skipped entirely
+  // for tables without visualizations.
+  const validatedTable: ValidatedTable | null = useMemo(() => {
+    if (tableVisualizations.length === 0) return null
+    const result = zTable.safeParse(searchedTable)
+    if (!result.success) console.error(result.error)
+    return result.success ? result.data : null
+  }, [searchedTable, tableVisualizations.length])
 
   const handleDelete = useCallback(
     (rowIds?: string[]) => {
@@ -125,21 +136,22 @@ export const TableContainer = ({ id, table, updateTable, locale }: TableContaine
         <div
           key="Visualizations"
           className={`pt-2 grid w-full gap-4 transition-all ${
-            tableVisualizations.length > 0 && unfilteredRows > 0 ? "" : "hidden"
+            tableVisualizations.length > 0 && unfilteredRows > 0 && validatedTable != null ? "" : "hidden"
           }`}
         >
-          {tableVisualizations.map((vs: any, i: number) => {
-            return (
-              <Figure
-                key={table.id + "_" + String(i)}
-                tableInput={searchedTable}
-                visualizationInput={vs}
-                locale={locale}
-                handleDelete={handleDelete}
-                handleUndo={handleUndo}
-              />
-            )
-          })}
+          {validatedTable != null &&
+            tableVisualizations.map((vs: any, i: number) => {
+              return (
+                <Figure
+                  key={table.id + "_" + String(i)}
+                  tableInput={validatedTable}
+                  visualizationInput={vs}
+                  locale={locale}
+                  handleDelete={handleDelete}
+                  handleUndo={handleUndo}
+                />
+              )
+            })}
         </div>
       </div>
     </div>

--- a/packages/data-collector/src/components/consent_form_viz/types.ts
+++ b/packages/data-collector/src/components/consent_form_viz/types.ts
@@ -1,3 +1,11 @@
+// Matching feldspar's Text/Translatable (duplicated like visualization_plugin/types.ts
+// to keep the plugin self-contained). Previously `Text` silently resolved to the DOM
+// global Text node type.
+export interface Translatable {
+  translations: { [locale: string]: string }
+}
+export type Text = Translatable | string
+
 export interface PropsUIPromptConsentFormTableViz {
   __type__: "PropsUIPromptConsentFormTableViz"
   id: string

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/figure.tsx
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/figure.tsx
@@ -1,4 +1,4 @@
-import { VisualizationData, ChartVisualizationData, TextVisualizationData, zTable, zVisualizationType } from './types'
+import { VisualizationData, ChartVisualizationData, TextVisualizationData, Table, zVisualizationType } from './types'
 import { memo, useEffect, useMemo, useState } from 'react'
 
 import useVisualizationData from './visualizationDataFunctions/useVisualizationData'
@@ -14,7 +14,7 @@ const doubleTypes = ['wordcloud']
 type ShowStatus = 'hidden' | 'visible' | 'double'
 
 export interface FigureProps {
-  tableInput: any
+  tableInput: Table
   visualizationInput: any
   locale: string
   handleDelete: (rowIds: string[]) => void
@@ -28,18 +28,16 @@ export const Figure = ({
   handleDelete,
   handleUndo
 }: FigureProps): JSX.Element => {
-  const tableValidator = useMemo(() => zTable.safeParse(tableInput), [tableInput])
   const visualizationValidator = useMemo(() => zVisualizationType.safeParse(visualizationInput), [visualizationInput])
 
-  if (!tableValidator.success || !visualizationValidator.success) {
-    if (!tableValidator.success) console.error(tableValidator.error)
-    if (!visualizationValidator.success) console.error(visualizationValidator.error)
+  if (!visualizationValidator.success) {
+    console.error(visualizationValidator.error)
     return <div />
   }
 
   return (
     <FigureComponent
-      table={tableValidator.data}
+      table={tableInput}
       visualization={visualizationValidator.data}
       locale={locale}
       handleDelete={handleDelete}
@@ -49,7 +47,7 @@ export const Figure = ({
 }
 
 export interface ValidatedFigureProps {
-  table: z.infer<typeof zTable>
+  table: Table
   visualization: z.infer<typeof zVisualizationType>
   locale: string
   handleDelete: (rowIds: string[]) => void

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/types.ts
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/types.ts
@@ -15,11 +15,35 @@ export type Translatable = z.infer<typeof zTranslatable>
 export const zLabel = z.union([zTranslatable, z.string()])
 export type Label = z.infer<typeof zLabel>
 
-// Table type, but only taking what we need
+// Table type, but only taking what we need.
+// body.rows is validated in place via z.custom and passed through BY REFERENCE:
+// zod's normal array/object schemas reconstruct (deep-clone) their output, which
+// for a 65k-row table retained one full copy per figure for the page lifetime
+// (issue #122). The custom predicate keeps zod as the validation gate with zero
+// row allocations. Trade-off: a validation failure yields one custom issue, not
+// zod's per-path nested errors.
+// zTableRow is the shape's source of truth; isRowArray is its zero-allocation
+// implementation (conformance-tested).
+export const zTableRow = z.object({ id: z.string(), cells: z.array(z.string()) })
+export type TableRow = z.infer<typeof zTableRow>
+
+export function isRowArray (rows: unknown): rows is TableRow[] {
+  return (
+    Array.isArray(rows) &&
+    rows.every(
+      (row) =>
+        row != null &&
+        typeof (row as TableRow).id === 'string' &&
+        Array.isArray((row as TableRow).cells) &&
+        (row as TableRow).cells.every((cell) => typeof cell === 'string')
+    )
+  )
+}
+
 export const zTable = z.object({
   id: z.string(),
   head: z.object({ cells: z.array(z.string()) }),
-  body: z.object({ rows: z.array(z.object({ id: z.string(), cells: z.array(z.string()) })) }),
+  body: z.object({ rows: z.custom<TableRow[]>(isRowArray, { message: 'body.rows must be an array of { id: string, cells: string[] }' }) }),
 })
 export type Table = z.infer<typeof zTable>
 

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.test.ts
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.test.ts
@@ -1,0 +1,78 @@
+import { selectVisualizationColumns } from './selectVisualizationColumns'
+import { Table, VisualizationType } from '../types'
+
+function makeTable (): Table {
+  return {
+    id: 'tiktok_videos',
+    head: { cells: ['date', 'title', 'url', 'duration', 'category'] },
+    body: {
+      rows: [
+        { id: 'r1', cells: ['2024-01-01', 'video one', 'https://a.example', '10', 'music'] },
+        { id: 'r2', cells: ['2024-01-02', 'video two', 'https://b.example', '20', 'sports'] }
+      ]
+    }
+  }
+}
+
+describe('selectVisualizationColumns', () => {
+  it('keeps only the columns a chart visualization reads', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'per day' },
+      type: 'line',
+      group: { column: 'date' },
+      values: [{ column: 'duration', aggregate: 'sum', group_by: 'category' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['date', 'duration', 'category'])
+    expect(projected.body.rows).toEqual([
+      { id: 'r1', cells: ['2024-01-01', '10', 'music'] },
+      { id: 'r2', cells: ['2024-01-02', '20', 'sports'] }
+    ])
+    expect(projected.id).toBe('tiktok_videos')
+  })
+
+  it('does not materialize the .COUNT pseudo-column', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'count per day' },
+      type: 'bar',
+      group: { column: 'date' },
+      values: [{ column: '.COUNT' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['date'])
+  })
+
+  it('keeps textColumn and valueColumn for a wordcloud', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'words' },
+      type: 'wordcloud',
+      textColumn: 'title',
+      valueColumn: 'duration'
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['title', 'duration'])
+    expect(projected.body.rows[0].cells).toEqual(['video one', '10'])
+  })
+
+  it('drops referenced columns that do not exist in the table (worker reports the error)', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'bad' },
+      type: 'bar',
+      group: { column: 'no_such_column' },
+      values: [{ column: 'duration' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.head.cells).toEqual(['duration'])
+  })
+
+  it('preserves row ids so rowId-based deletion still works', () => {
+    const visualization: VisualizationType = {
+      title: { en: 'per day' },
+      type: 'area',
+      group: { column: 'date' },
+      values: [{ column: 'duration' }]
+    }
+    const projected = selectVisualizationColumns(makeTable(), visualization)
+    expect(projected.body.rows.map((r) => r.id)).toEqual(['r1', 'r2'])
+  })
+})

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.ts
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.ts
@@ -1,0 +1,44 @@
+import { ChartVisualization, TextVisualization, VisualizationType, Table } from '../types'
+
+/**
+ * Project a table down to only the columns the visualization reads, so that
+ * postMessage structured-clones a fraction of the table into the worker
+ * (issue #122). The worker resolves columns by name (getTableColumn), so the
+ * projection is transparent to it. Display and donation data are unaffected.
+ */
+export function selectVisualizationColumns (table: Table, visualization: VisualizationType): Table {
+  const columns = visualizationColumns(visualization).filter((column) => table.head.cells.includes(column))
+  const indices = columns.map((column) => table.head.cells.indexOf(column))
+  return {
+    id: table.id,
+    head: { cells: columns },
+    body: {
+      rows: table.body.rows.map((row) => ({
+        id: row.id,
+        cells: indices.map((index) => row.cells[index])
+      }))
+    }
+  }
+}
+
+function visualizationColumns (visualization: VisualizationType): string[] {
+  const columns = new Set<string>()
+
+  if (['line', 'bar', 'area'].includes(visualization.type)) {
+    const chart = visualization as ChartVisualization
+    columns.add(chart.group.column)
+    for (const value of chart.values) {
+      if (value.column !== undefined) columns.add(value.column)
+      if (value.group_by !== undefined) columns.add(value.group_by)
+      if (value.z !== undefined) columns.add(value.z)
+    }
+  }
+
+  if (visualization.type === 'wordcloud') {
+    const text = visualization as TextVisualization
+    columns.add(text.textColumn)
+    if (text.valueColumn !== undefined) columns.add(text.valueColumn)
+  }
+
+  return Array.from(columns)
+}

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/useVisualizationData.tsx
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/useVisualizationData.tsx
@@ -1,5 +1,6 @@
 import { VisualizationType, VisualizationData, Table } from '../types'
 import { useEffect, useState } from 'react'
+import { selectVisualizationColumns } from './selectVisualizationColumns'
 
 type Status = 'loading' | 'success' | 'error'
 
@@ -9,33 +10,32 @@ export default function useVisualizationData (
 ): [VisualizationData | undefined, Status] {
   const [visualizationData, setVisualizationData] = useState<VisualizationData>()
   const [status, setStatus] = useState<Status>('loading')
-  const [worker, setWorker] = useState<Worker>()
 
   useEffect(() => {
+    if (window.Worker === undefined) {
+      setStatus('error')
+      return
+    }
+    setStatus('loading')
+    // Spawn a worker per computation and terminate it as soon as it answers,
+    // instead of keeping a persistent worker holding a clone of the table
+    // alive for the lifetime of the figure (issue #122).
     const worker = new Worker(
-      new URL('./visualizationDataWorker.ts', import.meta.url), {type: 'module'})
-    setWorker(worker)
+      new URL('./visualizationDataWorker.ts', import.meta.url), { type: 'module' })
+    worker.onmessage = (e: MessageEvent<{ status: Status, visualizationData: VisualizationData }>) => {
+      setVisualizationData(e.data.visualizationData)
+      setStatus(e.data.status)
+      worker.terminate()
+    }
+    worker.onerror = () => {
+      setStatus('error')
+      worker.terminate()
+    }
+    worker.postMessage({ table: selectVisualizationColumns(table, visualization), visualization })
     return () => {
       worker.terminate()
     }
-  }, [])
-
-  useEffect(() => {
-    if (worker != null && window.Worker !== undefined) {
-      setStatus('loading')
-      worker.onmessage = (e: MessageEvent<{ status: Status, visualizationData: VisualizationData }>) => {
-        try {
-          setVisualizationData(e.data.visualizationData)
-          setStatus(e.data.status)
-        } catch (e) {
-          console.log(e)
-          setVisualizationData(undefined)
-          setStatus('error')
-        }
-      }
-      worker.postMessage({ table, visualization })
-    }
-  }, [table, visualization, worker])
+  }, [table, visualization])
 
   return [visualizationData, status]
 }

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/zTable.test.ts
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/zTable.test.ts
@@ -1,0 +1,77 @@
+import { zTable, zTableRow, isRowArray } from './types'
+
+function makeTable () {
+  return {
+    id: 't1',
+    head: { cells: ['a', 'b'] },
+    body: {
+      rows: [
+        { id: 'r1', cells: ['1', '2'] },
+        { id: 'r2', cells: ['3', '4'] }
+      ]
+    },
+    originalBody: { rows: [] },
+    deletedRows: []
+  }
+}
+
+describe('zTable', () => {
+  it('passes rows through by reference (no deep clone)', () => {
+    const input = makeTable()
+    const result = zTable.safeParse(input)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.body.rows).toBe(input.body.rows)
+      expect(result.data.body.rows[0]).toBe(input.body.rows[0])
+    }
+  })
+
+  it('strips unknown keys from the outer object', () => {
+    const result = zTable.safeParse(makeTable())
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('originalBody')
+      expect(result.data).not.toHaveProperty('deletedRows')
+    }
+  })
+
+  it('rejects a non-string row id', () => {
+    const input = makeTable()
+    ;(input.body.rows[1] as any).id = 7
+    expect(zTable.safeParse(input).success).toBe(false)
+  })
+
+  it('rejects non-array cells', () => {
+    const input = makeTable()
+    ;(input.body.rows[0] as any).cells = 'not-an-array'
+    expect(zTable.safeParse(input).success).toBe(false)
+  })
+
+  it('rejects a non-string cell', () => {
+    const input = makeTable()
+    ;(input.body.rows[0] as any).cells = ['1', 2]
+    expect(zTable.safeParse(input).success).toBe(false)
+  })
+
+  it('rejects non-array rows', () => {
+    const input = makeTable()
+    ;(input.body as any).rows = { r1: {} }
+    expect(zTable.safeParse(input).success).toBe(false)
+  })
+
+  it('isRowArray conforms to zTableRow for representative rows', () => {
+    const cases: unknown[] = [
+      [{ id: 'r1', cells: ['a', 'b'] }],
+      [{ id: 'r1', cells: [] }],
+      [],
+      [{ id: 7, cells: ['a'] }],
+      [{ id: 'r1', cells: 'nope' }],
+      [{ id: 'r1', cells: ['a', 2] }],
+      [null],
+      'not-an-array'
+    ]
+    for (const rows of cases) {
+      expect(isRowArray(rows)).toBe(zTableRow.array().safeParse(rows).success)
+    }
+  })
+})

--- a/packages/data-collector/tsconfig.json
+++ b/packages/data-collector/tsconfig.json
@@ -22,6 +22,7 @@
 
     /* Path mapping */
     "baseUrl": ".",
+    "rootDir": ".",
     "paths": {
       "@/*": ["./src/*"]
     },
@@ -31,7 +32,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"]
 }

--- a/packages/feldspar/src/index.ts
+++ b/packages/feldspar/src/index.ts
@@ -9,22 +9,23 @@ export {DataSubmissionPageFactory} from './framework/visualization/react/factori
 export {PromptFactory} from './framework/visualization/react/ui/prompts/factory'
 export {ReactFactoryContext} from './framework/visualization/react/factory'
 
-// EXPORTS ADDED BY NdS
+// D3I additions to the upstream feldspar exports
 export { default } from './framework/text_bundle'
 export { Translator } from './framework/translator'
 export { Table } from './framework/types/commands'
-export { 
-  Title1, 
+export {
+  Title1,
   Title2,
   Title3,
-  Title4, 
+  Title4,
   BodyLarge,
   BodySmall,
 } from './framework/visualization/react/ui/elements/text'
-export { 
+export {
   LabelButton,
   PrimaryButton,
 } from './framework/visualization/react/ui/elements/button'
-export { 
+export {
   isInstanceOf,
 } from './framework/helpers'
+export { DonateButtons } from './framework/visualization/react/ui/prompts/donate_buttons'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.3.2
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -100,6 +103,9 @@ importers:
       globals:
         specifier: ^17.5.0
         version: 17.7.0
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@26.0.1)
       postcss:
         specifier: ^8.5.10
         version: 8.5.19
@@ -112,6 +118,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.4
         version: 4.3.2
+      ts-jest:
+        specifier: 29.4.11
+        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.27.2)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1))(typescript@6.0.3)
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -199,7 +208,7 @@ importers:
         version: 4.3.2
       ts-jest:
         specifier: 29.4.11
-        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.27.2)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1))(typescript@6.0.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -630,20 +639,12 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/diff-sequences@30.3.0':
-    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/diff-sequences@30.4.0':
     resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/environment@30.4.1':
     resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect-utils@30.3.0':
-    resolution: {integrity: sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@30.4.1':
@@ -666,10 +667,6 @@ packages:
     resolution: {integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/pattern@30.0.1':
-    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/pattern@30.4.0':
     resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -682,10 +679,6 @@ packages:
     peerDependenciesMeta:
       node-notifier:
         optional: true
-
-  '@jest/schemas@30.0.5':
-    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/schemas@30.4.1':
     resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
@@ -709,10 +702,6 @@ packages:
 
   '@jest/transform@30.4.1':
     resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/types@30.3.0':
-    resolution: {integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/types@30.4.1':
@@ -2038,10 +2027,6 @@ packages:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
 
-  expect@30.3.0:
-    resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2369,10 +2354,6 @@ packages:
       ts-node:
         optional: true
 
-  jest-diff@30.3.0:
-    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-diff@30.4.1:
     resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2397,24 +2378,12 @@ packages:
     resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.3.0:
-    resolution: {integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-matcher-utils@30.4.1:
     resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.3.0:
-    resolution: {integrity: sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-message-util@30.4.1:
     resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-mock@30.3.0:
-    resolution: {integrity: sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-mock@30.4.1:
@@ -2429,10 +2398,6 @@ packages:
     peerDependenciesMeta:
       jest-resolve:
         optional: true
-
-  jest-regex-util@30.0.1:
-    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-regex-util@30.4.0:
     resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
@@ -2456,10 +2421,6 @@ packages:
 
   jest-snapshot@30.4.1:
     resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-util@30.3.0:
-    resolution: {integrity: sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-util@30.4.1:
@@ -2920,10 +2881,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  pretty-format@30.3.0:
-    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   pretty-format@30.4.1:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
@@ -3959,8 +3916,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/diff-sequences@30.3.0': {}
-
   '@jest/diff-sequences@30.4.0': {}
 
   '@jest/environment@30.4.1':
@@ -3969,10 +3924,6 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 26.0.1
       jest-mock: 30.4.1
-
-  '@jest/expect-utils@30.3.0':
-    dependencies:
-      '@jest/get-type': 30.1.0
 
   '@jest/expect-utils@30.4.1':
     dependencies:
@@ -4004,11 +3955,6 @@ snapshots:
       jest-mock: 30.4.1
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/pattern@30.0.1':
-    dependencies:
-      '@types/node': 26.0.1
-      jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
@@ -4042,10 +3988,6 @@ snapshots:
       v8-to-istanbul: 9.3.0
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/schemas@30.0.5':
-    dependencies:
-      '@sinclair/typebox': 0.34.48
 
   '@jest/schemas@30.4.1':
     dependencies:
@@ -4096,16 +4038,6 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/types@30.3.0':
-    dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.0.1
-      '@types/yargs': 17.0.35
-      chalk: 4.1.2
 
   '@jest/types@30.4.1':
     dependencies:
@@ -4529,8 +4461,8 @@ snapshots:
 
   '@types/jest@30.0.0':
     dependencies:
-      expect: 30.3.0
-      pretty-format: 30.3.0
+      expect: 30.4.1
+      pretty-format: 30.4.1
 
   '@types/json-schema@7.0.15': {}
 
@@ -5329,15 +5261,6 @@ snapshots:
 
   exit-x@0.2.2: {}
 
-  expect@30.3.0:
-    dependencies:
-      '@jest/expect-utils': 30.3.0
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
-
   expect@30.4.1:
     dependencies:
       '@jest/expect-utils': 30.4.1
@@ -5593,7 +5516,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -5704,13 +5627,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-diff@30.3.0:
-    dependencies:
-      '@jest/diff-sequences': 30.3.0
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.3.0
-
   jest-diff@30.4.1:
     dependencies:
       '@jest/diff-sequences': 30.4.0
@@ -5750,7 +5666,7 @@ snapshots:
       jest-regex-util: 30.4.0
       jest-util: 30.4.1
       jest-worker: 30.4.1
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -5760,31 +5676,12 @@ snapshots:
       '@jest/get-type': 30.1.0
       pretty-format: 30.4.1
 
-  jest-matcher-utils@30.3.0:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.3.0
-      pretty-format: 30.3.0
-
   jest-matcher-utils@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
       jest-diff: 30.4.1
       pretty-format: 30.4.1
-
-  jest-message-util@30.3.0:
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@jest/types': 30.3.0
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      picomatch: 4.0.3
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
 
   jest-message-util@30.4.1:
     dependencies:
@@ -5794,16 +5691,10 @@ snapshots:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       jest-util: 30.4.1
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
-
-  jest-mock@30.3.0:
-    dependencies:
-      '@jest/types': 30.3.0
-      '@types/node': 26.0.1
-      jest-util: 30.3.0
 
   jest-mock@30.4.1:
     dependencies:
@@ -5814,8 +5705,6 @@ snapshots:
   jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
     optionalDependencies:
       jest-resolve: 30.4.1
-
-  jest-regex-util@30.0.1: {}
 
   jest-regex-util@30.4.0: {}
 
@@ -5912,19 +5801,10 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.7.4
+      semver: 7.8.5
       synckit: 0.11.13
     transitivePeerDependencies:
       - supports-color
-
-  jest-util@30.3.0:
-    dependencies:
-      '@jest/types': 30.3.0
-      '@types/node': 26.0.1
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      graceful-fs: 4.2.11
-      picomatch: 4.0.3
 
   jest-util@30.4.1:
     dependencies:
@@ -5933,7 +5813,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.5
 
   jest-validate@30.4.1:
     dependencies:
@@ -6109,7 +5989,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -6340,12 +6220,6 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
-
-  pretty-format@30.3.0:
-    dependencies:
-      '@jest/schemas': 30.0.5
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
 
   pretty-format@30.4.1:
     dependencies:
@@ -6790,7 +6664,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.27.2)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -6808,6 +6682,7 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       babel-jest: 30.4.1(@babel/core@7.29.0)
+      esbuild: 0.27.2
       jest-util: 30.4.1
 
   tslib@2.8.1: {}

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -29,11 +29,15 @@ Run from the repo root, e.g.:
 | `memtest.cjs` | RSS at checkpoints, example-platform flow | quick smoke: does a huge upload stream without ballooning (ADR-0026)? |
 | `tiktok-memtest.cjs` | 1 s RSS timeline, TikTok flow | first-pass profiling of a real DDP |
 | `memtest-v2.cjs` | median RSS/PSS over stable windows, per-process-type PSS, forced-GC diagnostic, workload-identity checks | rigorous A/B between builds (use `RUN_LABEL=` to tag runs; emits `RESULT>` JSON lines) |
-| `memtest-v3-peak.cjs` | peak instantaneous footprint (250 ms sampling) of the whole tree and of the renderer process alone | threshold questions — e.g. iOS WebKit kills pages around 1–1.5 GB instantaneous, so peak renderer RSS is the metric that matters |
+| `memtest-v3-peak.cjs` | peak instantaneous footprint (250 ms sampling) of the whole tree and of the renderer process alone, broken down per phase (including a `donate` phase that clicks through consent) | threshold questions — e.g. iOS WebKit kills pages around 1–1.5 GB instantaneous, so peak renderer RSS is the metric that matters |
 
 `tiktok-memtest.cjs` and the v2/v3 harnesses expect the TikTok flow
 headings; adapt the two `getByRole('heading', …)` selectors to target a
-different platform.
+different platform. `memtest-v3-peak.cjs` also clicks the donate button at
+the end of the flow to capture the donation-serialization spike as its own
+`rendererPeaksByPhase.donate` entry; the button label selector
+(`'Yes, share for research'`, the default from `generate_review_data_prompt`)
+must be adapted alongside the two heading selectors for non-TikTok flows.
 
 ## Methodology notes (hard-won)
 

--- a/scripts/benchmarks/memtest-v3-peak.cjs
+++ b/scripts/benchmarks/memtest-v3-peak.cjs
@@ -1,5 +1,5 @@
 // Peak-pressure harness: samples every 250 ms across the WHOLE flow
-// (navigation -> consent page + settle), tracking the maximum instantaneous
+// (navigation -> consent page -> donate + settle), tracking the maximum instantaneous
 // footprint of (a) the full browser process tree and (b) the renderer
 // process alone (closest proxy for iOS WebContent). Reports absolute peaks.
 const { chromium } = require('@playwright/test');
@@ -72,6 +72,14 @@ function rssKb(pid) {
 
   phase = 'render+settle';
   await page.waitForTimeout(12000);
+
+  phase = 'donate';
+  // Label comes from generate_review_data_prompt; adapt alongside the two
+  // heading selectors when targeting a different platform/flow.
+  await page.getByText('Yes, share for research').click();
+  // The serialization spike is synchronous with the click; a fixed settle
+  // captures it without coupling to whatever page the flow shows next.
+  await page.waitForTimeout(8000);
   clearInterval(sampler);
 
   const mb = (kb) => Math.round(kb / 1024);


### PR DESCRIPTION
Solving(ish) issue #122, the consent-viz page can push renderer memory into levels that will cause WebKit-based browsers (which is basically all of them) to get killed by jetsam. We think that this is about 1GB to 1.5GB, but we don't know for sure. We have two causes in the visualization path (and here I mean the tables too, everything we show.) Every visualization structured-cloned the entire table into a persistent Web Worker, and we were parsing the consent tables twice on mount.

Claude identified the donate step as being the heaviest memory burden, but of course that's because we're using fakebridge and it dumps the entire stringified donation into the console. I'll test a build to see what it actually looks like afterwards.


**Changes:**
This is ~three~ four memory changes in the consent-viz component. The only shared upstream surface is an additional export line so we can align on buttons again.

1. **Column projection before the worker** selectVisualizationColumns(table, viz) builds a small table containing only the columns that visualization actually reads (x column, y columns, group_by, textColumn/valueColumn; row ids kept so click-to-delete still works). Only that projection crosses postMessage.
2. **Ephemeral workers** — one fresh worker per computation, terminate()d the moment it answers and in effect cleanup (which also kills stale in-flight computes when the table changes).
3. **Single mount parse** — the [props.tables] effect now compares against the previous props reference, so the lazy useState initializer is the only mount-time parse (StrictMode-safe).
4. **Stuff with Zod** We use Zod for validation, but if we use  .parse(), it makes deep copies. We can separate out the validation and the cloning if we switch to z.custom which validates in place and passes the value by reference. 


**Benchmark**

- −310 MB peak (−23%), and the donate-click spike — which the new harness phase revealed as the true flow-wide peak, previously unmeasured — collapsed from +314 MB to +33 MB over settle.
- The ≤ ~824 MB acceptance line was not met (989–1029). The final reviewer found why, and it's actionable: figure.tsx:31 zod-validates the _full_ table per figure and the memo retains that deep copy for the page lifetime — one frame above our projection, untouched by the worker fix. Reordering (validate viz spec → project columns → zod-parse only the projection) is non-data-losing and is now filed in PENDING_ISSUES.md as the next lever. I'd treat #122 as "major improvement landed, residual tracked" rather than holding this branch for it — your call.

Edit: Actually, we can't TRULY tell anything about the true spike from donating here so ignore that part because it's not using the live bridge.

<img width="1332" height="290" alt="memtab_consent_form" src="https://github.com/user-attachments/assets/d31f8a5f-d1c0-479e-8e33-adda8812801d" />

