### PR TITLE
Fix/viz dateformat memory

### DIFF
--- a/docs/decisions/0032-visualization-workers-are-ephemeral-and-column-scoped.md
+++ b/docs/decisions/0032-visualization-workers-are-ephemeral-and-column-scoped.md
@@ -9,6 +9,15 @@ applies_to:
 priority: default
 companions:
     - packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/selectVisualizationColumns.test.ts
+checks:
+    - desc: the hook still projects columns before postMessage
+      grep: 'selectVisualizationColumns\('
+      in: ["packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/useVisualizationData.tsx"]
+      expect: present
+    - desc: the hook still terminates its workers
+      grep: 'worker\.terminate\(\)'
+      in: ["packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/useVisualizationData.tsx"]
+      expect: present
 ---
 
 # Visualization workers are ephemeral and column-scoped

--- a/docs/decisions/0034-hold-participant-flow-peak-memory-to-the-824-mb-reference-budget.md
+++ b/docs/decisions/0034-hold-participant-flow-peak-memory-to-the-824-mb-reference-budget.md
@@ -17,6 +17,7 @@ Peak instantaneous renderer RSS across the participant flow (upload → consent 
 ## Guidance
 
 - Before merging memory-relevant changes to the consent/viz flow, run `scripts/benchmarks/memtest-v3-peak.cjs` (donate phase included) on the reference DDP and compare per-phase peaks against the budget; deltas over each run's own idle baseline are the comparable A/B metric.
+- The benchmark build must bake in a config with visualizations on the big table (fixture in `scripts/benchmarks/fixtures/`) — under a viz-less config the entire chart pipeline is invisible to the measurement (2026-07-17: a ~4 GB chart-compute burst was undetectable until the profiling config matched the study's).
 - Absolute numbers count only from a production-representative build with a non-logging data-submission sink — `NODE_ENV=development` builds run FakeBridge (which logs the full donation) and StrictMode React, inflating every phase; treat those runs as relative evidence only.
 - Track `peakTreeMb` alongside renderer RSS (Pyodide's worker heap lives in the same process tree), and treat real iOS hardware/WebKit as the final authority for the absolute gate.
 

--- a/docs/decisions/0035-per-row-work-over-participant-tables-must-not-allocate.md
+++ b/docs/decisions/0035-per-row-work-over-participant-tables-must-not-allocate.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+date: "2026-07-17"
+category: Data collector
+applies_to:
+    - packages/data-collector/src/components/consent_form_viz/**
+priority: default
+companions:
+    - packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/formatDate.test.ts
+checks:
+    - desc: no per-call ICU construction via toLocaleString in the per-row viz data pipeline
+      grep: 'toLocaleString\('
+      in: ["packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/**"]
+      expect: absent
+    - desc: Intl formatter construction only in util.ts hoisted sites (whole consent-viz tree)
+      grep: 'new Intl\.'
+      in: ["packages/data-collector/src/components/consent_form_viz/**"]
+      except: ["**/util.ts", "**/*.test.ts"]
+      expect: absent
+    - desc: no zod parsing inside the per-row pipeline (validation happens once at the table boundary)
+      grep: '\.safeParse\(|zTable(Row)?\.parse\('
+      in: ["packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/**"]
+      except: ["**/*.test.ts"]
+      expect: absent
+---
+
+# Per-row work over participant tables must not allocate
+
+## Decision
+
+Code that runs per table row must not construct heavyweight objects or per-row intermediate structures inside the loop: construct once above the loop and reuse. Prefer bulk/columnar transforms over new per-row closures.
+
+## Guidance
+
+- Anything a row-loop body needs — an `Intl.DateTimeFormat`, a compiled regex, a zod parse, a lookup table — is constructed once above the loop and captured; review rejects any allocation whose count scales with row count. Tables here reach 65k+ rows.
+- Formatting rows with `toLocaleString` is per-row ICU construction in disguise; use a hoisted `Intl.DateTimeFormat` as `formatDate` does. The frontmatter grep checks enforce this for the viz data pipeline; keep new `Intl.*` construction sites inside `util.ts` so the carve-out stays narrow.
+- Per-row helper-library calls that allocate (e.g. the `_.zip`/`_.fromPairs` pair in `serializeRow`) are the same pattern at donation time — acceptable only where measured, and the first place to look when the donate-phase peak grows.
+- A new per-row transform ships with an O(1)-allocation tripwire (extend the construction-count spy pattern in `formatDate.test.ts`).
+- The structural end-state is columnar table processing (bulk ops over per-row objects) — tracked as a follow-up; new code should not deepen the row-wise idiom.
+
+## Why
+
+One `Intl.DateTimeFormat` per row measured +1697 MB RSS per chart computation (2026-07-16/17 production profiling: consent flow peaked at 4.9 GB pre-fix, 839 MB after hoisting) — the per-row-allocation class, not the datetime instance, is what keeps killing iPhone donations.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -58,6 +58,7 @@ Load the ADR(s) whose filename matches the area you are touching.
 - [0031 — Consent-page memory work must never shrink the donated dataset](./0031-consent-page-memory-work-must-never-shrink-the-donated-dataset.md)
 - [0032 — Visualization workers are ephemeral and column-scoped](./0032-visualization-workers-are-ephemeral-and-column-scoped.md)
 - [0033 — Consent-viz donation must not route through DataSubmissionPage's factory data path](./0033-consent-viz-donation-must-not-route-through-datasubmissionpage-s-factory-data-path.md)
+- [0035 — Per-row work over participant tables must not allocate](./0035-per-row-work-over-participant-tables-must-not-allocate.md)
 
 ### Performance
 

--- a/packages/data-collector/eslint.config.js
+++ b/packages/data-collector/eslint.config.js
@@ -36,4 +36,26 @@ export default [
       ],
     },
   },
+  {
+    // ADR-0035: per-row loops in the viz data pipeline must not construct
+    // ICU machinery per call — hoist Intl formatters (see util.ts formatDate).
+    files: ['src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/**/*.{ts,tsx}'],
+    ignores: [
+      'src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/util.ts',
+      'src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/**/*.test.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.property.name=/^toLocale(Date|Time)?String$/]",
+          message: 'Constructs ICU machinery per call; hoist an Intl.DateTimeFormat instead (ADR-0035, see util.ts formatDate).',
+        },
+        {
+          selector: "NewExpression[callee.object.name='Intl']",
+          message: 'Construct Intl formatters once in util.ts and reuse (ADR-0035).',
+        },
+      ],
+    },
+  },
 ]

--- a/packages/data-collector/package.json
+++ b/packages/data-collector/package.json
@@ -12,13 +12,14 @@
     "react-dom": "19.2.7"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@tailwindcss/postcss": "^4.2.4",
     "@types/jest": "30.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.2",
     "@typescript-eslint/eslint-plugin": "^8.59.3",
     "@typescript-eslint/parser": "^8.60.1",
     "@vitejs/plugin-react": "^6.0.2",
-    "@tailwindcss/postcss": "^4.2.4",
     "autoprefixer": "^10.4.21",
     "eslint": "^10.1.0",
     "eslint-plugin-react-hooks": "^7.0.0",
@@ -40,6 +41,7 @@
     "preview": "vite preview",
     "start": "vite",
     "test": "jest",
+    "lint": "eslint src",
     "clean": "rimraf dist node_modules"
   },
   "browserslist": {

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/formatDate.test.ts
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/formatDate.test.ts
@@ -1,0 +1,133 @@
+import { formatDate } from './util'
+import { DateFormat } from '../types'
+
+function makeIsoDates (count: number): string[] {
+  // spread ~1000 dates across a few months, at varying hours, so month/weekday/hour
+  // formatting all see a range of distinct values
+  const dates: string[] = []
+  const start = new Date('2024-01-01T00:00:00.000Z').getTime()
+  const hourMs = 1000 * 60 * 60
+  for (let i = 0; i < count; i++) {
+    dates.push(new Date(start + i * hourMs * 7).toISOString())
+  }
+  return dates
+}
+
+describe('formatDate construction-count regression (memory tripwire)', () => {
+  const cyclicFormats: DateFormat[] = [
+    'month_cycle',
+    'weekday_cycle',
+    'hour_cycle',
+    'month',
+    'day',
+    'hour'
+  ]
+
+  cyclicFormats.forEach((format) => {
+    it(`does not construct one Intl.DateTimeFormat per row for format="${format}"`, () => {
+      const dates = makeIsoDates(1000)
+      const spy = jest.spyOn(Intl, 'DateTimeFormat')
+      try {
+        formatDate(dates, format)
+        expect(spy.mock.calls.length).toBeLessThan(10)
+      } finally {
+        spy.mockRestore()
+      }
+    })
+  })
+})
+
+describe('formatDate output equivalence', () => {
+  it('formats "year"', () => {
+    const dates = ['2020-03-01T00:00:00.000Z', '2021-06-15T00:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'year')
+    const expected = dates.map((d) => new Date(d).getFullYear().toString())
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+
+  it('formats "quarter"', () => {
+    const dates = ['2020-01-15T00:00:00.000Z', '2020-05-15T00:00:00.000Z', '2020-11-15T00:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'quarter')
+    const expected = dates.map((d) => {
+      const date = new Date(d)
+      const year = date.getFullYear().toString()
+      const quarter = Math.floor(date.getMonth() / 3) + 1
+      return `${year}-Q${quarter}`
+    })
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+
+  it('formats "month"', () => {
+    const dates = ['2020-01-15T00:00:00.000Z', '2020-07-04T00:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'month')
+    const monthFormatter = new Intl.DateTimeFormat('default', { month: 'short' })
+    const expected = dates.map((d) => {
+      const date = new Date(d)
+      const year = date.getFullYear().toString()
+      const month = monthFormatter.format(date)
+      return `${year}-${month}`
+    })
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+
+  it('formats "day"', () => {
+    const dates = ['2020-01-15T00:00:00.000Z', '2020-07-04T00:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'day')
+    const monthFormatter = new Intl.DateTimeFormat('default', { month: 'short' })
+    const expected = dates.map((d) => {
+      const date = new Date(d)
+      const year = date.getFullYear().toString()
+      const month = monthFormatter.format(date)
+      const day = date.getDate().toString()
+      return `${year}-${month}-${day}`
+    })
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+
+  it('formats "hour"', () => {
+    const dates = ['2020-01-15T08:00:00.000Z', '2020-07-04T23:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'hour')
+    const monthFormatter = new Intl.DateTimeFormat('default', { month: 'short' })
+    const expected = dates.map((d) => {
+      const date = new Date(d)
+      const year = date.getFullYear().toString()
+      const month = monthFormatter.format(date)
+      const day = date.getDate().toString()
+      const hour = date.getHours()
+      return `${year}-${month}-${day} ${hour}:00`
+    })
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+
+  it('formats "month_cycle"', () => {
+    const dates = ['2020-01-15T00:00:00.000Z', '2020-07-04T00:00:00.000Z', '2020-12-25T00:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'month_cycle')
+    const intlFormatter = new Intl.DateTimeFormat('default', { month: 'long' })
+    const expected = dates.map((d) => intlFormatter.format(new Date(d)))
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+
+  it('formats "weekday_cycle"', () => {
+    const dates = ['2023-11-06T00:00:00.000Z', '2023-11-09T00:00:00.000Z', '2023-11-12T00:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'weekday_cycle')
+    const intlFormatter = new Intl.DateTimeFormat('default', { weekday: 'long' })
+    const expected = dates.map((d) => intlFormatter.format(new Date(d)))
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+
+  it('formats "hour_cycle"', () => {
+    const dates = ['2020-01-15T08:00:00.000Z', '2020-01-15T23:00:00.000Z']
+    const [formatted, sortable] = formatDate(dates, 'hour_cycle')
+    const intlFormatter = new Intl.DateTimeFormat('default', { hour: 'numeric', hour12: false })
+    const expected = dates.map((d) => intlFormatter.format(new Date(d)))
+    expect(formatted).toEqual(expected)
+    expect(sortable).not.toBeNull()
+  })
+})

--- a/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/util.ts
+++ b/packages/data-collector/src/components/consent_form_viz/visualization_plugin/visualizationDataFunctions/util.ts
@@ -23,26 +23,29 @@ export function formatDate(
   }
 
   if (format === "month") {
+    const monthFormatter = new Intl.DateTimeFormat("default", { month: "short" });
     formatter = (date) => {
       const year = date.getFullYear().toString();
-      const month = date.toLocaleString("default", { month: "short" });
+      const month = monthFormatter.format(date);
       return `${year}-${month}`;
     };
   }
 
   if (format === "day") {
+    const monthFormatter = new Intl.DateTimeFormat("default", { month: "short" });
     formatter = (date) => {
       const year = date.getFullYear().toString();
-      const month = date.toLocaleString("default", { month: "short" });
+      const month = monthFormatter.format(date);
       const day = date.getDate().toString();
       return `${year}-${month}-${day}`;
     };
   }
 
   if (format === "hour") {
+    const monthFormatter = new Intl.DateTimeFormat("default", { month: "short" });
     formatter = (date) => {
       const year = date.getFullYear().toString();
-      const month = date.toLocaleString("default", { month: "short" });
+      const month = monthFormatter.format(date);
       const day = date.getDate().toString();
       const hour = date.getHours();
       return `${year}-${month}-${day} ${hour}:00`;
@@ -50,26 +53,20 @@ export function formatDate(
   }
 
   if (format === "month_cycle") {
-    formatter = (date) => {
-      const intlFormatter = new Intl.DateTimeFormat("default", { month: "long" });
-      return intlFormatter.format(date);
-    };
+    const intlFormatter = new Intl.DateTimeFormat("default", { month: "long" });
+    formatter = (date) => intlFormatter.format(date);
     // can be any year, starting at january
     domain = [new Date("2000-01-01").getTime(), new Date("2001-01-01").getTime()];
   }
   if (format === "weekday_cycle") {
-    formatter = (date) => {
-      const intlFormatter = new Intl.DateTimeFormat("default", { weekday: "long" });
-      return intlFormatter.format(date);
-    };
+    const intlFormatter = new Intl.DateTimeFormat("default", { weekday: "long" });
+    formatter = (date) => intlFormatter.format(date);
     // can be any full week, starting at monday
     domain = [new Date("2023-11-06").getTime(), new Date("2023-11-13").getTime()];
   }
   if (format === "hour_cycle") {
-    formatter = (date) => {
-      const intlFormatter = new Intl.DateTimeFormat("default", { hour: "numeric", hour12: false });
-      return intlFormatter.format(date);
-    };
+    const intlFormatter = new Intl.DateTimeFormat("default", { hour: "numeric", hour12: false });
+    formatter = (date) => intlFormatter.format(date);
     // can be any day, starting at midnight
     domain = [new Date("2000-01-01").getTime(), new Date("2000-01-02").getTime()];
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.7.0(jiti@2.7.0))
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.3.2
@@ -589,6 +592,15 @@ packages:
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
@@ -3833,6 +3845,10 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.7.0(jiti@2.7.0))':
+    optionalDependencies:
+      eslint: 10.7.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -55,3 +55,16 @@ must be adapted alongside the two heading selectors for non-TikTok flows.
   `git write-tree` / tree hashes and dist digests, use one Playwright
   installation (one Chromium build) for all runs, and interleave runs
   in randomized order.
+
+### Visualization-bearing config (required for consent/chart phases)
+
+The peak harness only exercises the chart pipeline if the built config
+attaches `visualizations` to the big table — a config where the largest
+table has no `visualizations` skips chart compute entirely, and the
+`donate`/consent phase peaks read as flat and misleadingly low. Before
+building the benchmark artifact, copy
+`scripts/benchmarks/fixtures/tiktok_config.with-watchviz.json` over
+`packages/python/port/configs/tiktok_config.json`, then build as usual.
+2026-07-17 finding: under the viz-less default config, a ~4 GB
+chart-compute burst on `tiktok_watch_history` was completely invisible
+to the harness — the fixture surfaces it.

--- a/scripts/benchmarks/fixtures/tiktok_config.with-watchviz.json
+++ b/scripts/benchmarks/fixtures/tiktok_config.with-watchviz.json
@@ -1,0 +1,425 @@
+{
+  "platform_info": {
+    "name": "TikTok",
+    "filetypes": [
+      "json",
+      "txt"
+    ],
+    "languages": [
+      "en",
+      "nl"
+    ],
+    "description": "Handles DDPs in English and Dutch. For the JSON format, both user_data.json and user_data_tiktok.json are tried automatically. English DDPs in TXT format have not yet been tested. If you find anything wrong with the data donation flows, please report to datadonation@uu.nl and they will be fixed!",
+    "time_last_tested": "15-06-2026"
+  },
+  "tables": [
+    {
+      "id": "tiktok_activity_summary",
+      "title": {
+        "en": "Your TikTok activity summary",
+        "nl": "Samenvatting van je TikTok-activiteit"
+      },
+      "description": {
+        "en": "Summary counts of videos watched, commented on, and shared since account registration.",
+        "nl": "Overzicht van het aantal bekeken, becommentarieerde en gedeelde video's sinds registratie."
+      },
+      "headers": {
+        "Metric": {
+          "en": "Activity metric",
+          "nl": "Activiteitsmaat"
+        },
+        "Count": {
+          "en": "Count",
+          "nl": "Aantal"
+        }
+      },
+      "extractor": "activity_summary_to_df",
+      "documentation": {
+        "summary": "Summary counts of TikTok activity measures since account registration, such as the number of videos watched, commented on, and shared.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Metric": "Name of the activity metric",
+          "Count": "Total count for that metric since account registration."
+        }
+      }
+    },
+    {
+      "id": "tiktok_settings",
+      "title": {
+        "en": "Content preference keyword filters",
+        "nl": "Zoekwoordfilters voor contentvoorkeuren"
+      },
+      "description": {
+        "en": "Keyword filters applied to your Following and For You feeds.",
+        "nl": "Zoekwoordfilters die worden toegepast op je Volgend- en Voor Jou-feeds."
+      },
+      "headers": {
+        "Setting": {
+          "en": "Setting",
+          "nl": "Instelling"
+        },
+        "Keywords": {
+          "en": "Keywords",
+          "nl": "Trefwoorden"
+        }
+      },
+      "extractor": "settings_to_df",
+      "documentation": {
+        "summary": "Keyword filters applied to the participant's TikTok feeds.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Setting": "Name of the content preference setting.",
+          "Keywords": "Comma-separated list of keywords configured for this setting."
+        }
+      }
+    },
+    {
+      "id": "tiktok_watch_history",
+      "title": {
+        "en": "Watch history",
+        "nl": "Kijkgeschiedenis"
+      },
+      "description": {
+        "en": "TikTok videos you have watched.",
+        "nl": "TikTok-video's die je hebt bekeken."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "Link": {
+          "en": "Link",
+          "nl": "URL"
+        }
+      },
+      "extractor": "watch_history_to_df",
+      "documentation": {
+        "summary": "Each row represents one TikTok video the participant watched, including the date and video link.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the video was watched.",
+          "Link": "URL of the watched TikTok video."
+        }
+      },
+      "visualizations": [
+        {
+          "title": {
+            "en": "Videos watched over time",
+            "nl": "Bekeken video's in de loop van de tijd"
+          },
+          "type": "area",
+          "group": {
+            "column": "Date",
+            "dateFormat": "auto"
+          },
+          "values": [
+            {
+              "aggregate": "count",
+              "label": "Count"
+            }
+          ]
+        },
+        {
+          "title": {
+            "en": "Videos watched by hour of the day",
+            "nl": "Bekeken video's per uur van de dag"
+          },
+          "type": "bar",
+          "group": {
+            "column": "Date",
+            "dateFormat": "hour_cycle",
+            "label": "Hour of the day"
+          },
+          "values": [
+            {
+              "label": "Count"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "tiktok_favorite_videos",
+      "title": {
+        "en": "Favorite videos",
+        "nl": "Favoriete video's"
+      },
+      "description": {
+        "en": "Videos you have marked as favorites on TikTok.",
+        "nl": "Video's die je als favoriet hebt gemarkeerd op TikTok."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "Link": {
+          "en": "Link",
+          "nl": "URL"
+        }
+      },
+      "extractor": "favorite_videos_to_df",
+      "documentation": {
+        "summary": "Each row represents one TikTok video the participant marked as a favorite.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the video was marked as favorite.",
+          "Link": "URL of the favorited TikTok video."
+        }
+      }
+    },
+    {
+      "id": "tiktok_follower",
+      "title": {
+        "en": "Your followers",
+        "nl": "Je volgers"
+      },
+      "description": {
+        "en": "Accounts that follow you on TikTok.",
+        "nl": "Accounts die jou volgen op TikTok."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "UserName": {
+          "en": "Username",
+          "nl": "Gebruikersnaam"
+        }
+      },
+      "extractor": "follower_to_df",
+      "documentation": {
+        "summary": "Each row represents one account that follows the participant on TikTok.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the account started following.",
+          "UserName": "Username of the follower account."
+        }
+      }
+    },
+    {
+      "id": "tiktok_following",
+      "title": {
+        "en": "Accounts you follow",
+        "nl": "Accounts die je volgt"
+      },
+      "description": {
+        "en": "Accounts you follow on TikTok.",
+        "nl": "Accounts die je volgt op TikTok."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "UserName": {
+          "en": "Username",
+          "nl": "Gebruikersnaam"
+        }
+      },
+      "extractor": "following_to_df",
+      "documentation": {
+        "summary": "Each row represents one account that the participant follows on TikTok.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the participant started following this account.",
+          "UserName": "Username of the followed account."
+        }
+      }
+    },
+    {
+      "id": "tiktok_hashtag",
+      "title": {
+        "en": "Hashtags",
+        "nl": "Hashtags"
+      },
+      "description": {
+        "en": "Hashtags associated with your TikTok activity.",
+        "nl": "Hashtags gekoppeld aan je TikTok-activiteit."
+      },
+      "headers": {
+        "HashtagName": {
+          "en": "Hashtag",
+          "nl": "Hashtag"
+        },
+        "HashtagLink": {
+          "en": "Link",
+          "nl": "Link"
+        }
+      },
+      "extractor": "hashtag_to_df",
+      "documentation": {
+        "summary": "Each row represents one hashtag associated with the participant's TikTok activity.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "HashtagName": "Name of the hashtag.",
+          "HashtagLink": "URL link to the hashtag on TikTok."
+        }
+      }
+    },
+    {
+      "id": "tiktok_like_list",
+      "title": {
+        "en": "Videos you liked",
+        "nl": "Video's die je leuk vond"
+      },
+      "description": {
+        "en": "Videos you have liked on TikTok.",
+        "nl": "Video's die je leuk hebt gevonden op TikTok."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "Link": {
+          "en": "Link",
+          "nl": "Link"
+        }
+      },
+      "extractor": "like_list_to_df",
+      "documentation": {
+        "summary": "Each row represents one TikTok video the participant liked.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the video was liked.",
+          "Link": "URL of the liked TikTok video."
+        }
+      }
+    },
+    {
+      "id": "tiktok_searches",
+      "title": {
+        "en": "Search history",
+        "nl": "Zoekgeschiedenis"
+      },
+      "description": {
+        "en": "Search terms you have used on TikTok.",
+        "nl": "Zoektermen die je hebt gebruikt op TikTok."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "SearchTerm": {
+          "en": "Search term",
+          "nl": "Zoekterm"
+        }
+      },
+      "visualizations": [
+        {
+          "title": {
+            "en": "Most searched terms",
+            "nl": "Meest gezochte termen"
+          },
+          "type": "wordcloud",
+          "textColumn": "SearchTerm",
+          "tokenize": false
+        }
+      ],
+      "extractor": "searches_to_df",
+      "documentation": {
+        "summary": "Each row represents one search the participant performed on TikTok.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the search was performed.",
+          "SearchTerm": "The search term entered by the participant."
+        }
+      }
+    },
+    {
+      "id": "tiktok_share_history",
+      "title": {
+        "en": "Share history",
+        "nl": "Deelgeschiedenis"
+      },
+      "description": {
+        "en": "Content you have shared on TikTok, including when, what, and how.",
+        "nl": "Inhoud die je hebt gedeeld op TikTok, inclusief wanneer, wat en hoe."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "SharedContent": {
+          "en": "Shared content",
+          "nl": "Gedeelde inhoud"
+        },
+        "Link": {
+          "en": "Link",
+          "nl": "Link"
+        },
+        "Method": {
+          "en": "Method",
+          "nl": "Methode"
+        }
+      },
+      "extractor": "share_history_to_df",
+      "documentation": {
+        "summary": "Each row represents one piece of content the participant shared on TikTok.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the content was shared.",
+          "SharedContent": "Description of the shared content.",
+          "Link": "URL of the shared content.",
+          "Method": "Method used to share the content."
+        }
+      }
+    },
+    {
+      "id": "tiktok_comments",
+      "title": {
+        "en": "Your comments",
+        "nl": "Je reacties"
+      },
+      "description": {
+        "en": "Comments you have left on TikTok videos.",
+        "nl": "Reacties die je hebt achtergelaten op TikTok-video's."
+      },
+      "headers": {
+        "Date": {
+          "en": "Date",
+          "nl": "Datum en tijd"
+        },
+        "Comment": {
+          "en": "Comment",
+          "nl": "Reactie"
+        },
+        "Photo": {
+          "en": "Photo",
+          "nl": "Foto"
+        },
+        "Url": {
+          "en": "Url",
+          "nl": "Url"
+        }
+      },
+      "visualizations": [
+        {
+          "title": {
+            "en": "Most common words in your comments",
+            "nl": "Meest voorkomende woorden in je reacties"
+          },
+          "type": "wordcloud",
+          "textColumn": "Comment",
+          "tokenize": true
+        }
+      ],
+      "extractor": "comments_to_df",
+      "documentation": {
+        "summary": "Each row represents one comment the participant left on a TikTok video.",
+        "source_file": "user_data_tiktok.json or user_data.json",
+        "columns": {
+          "Date": "Timestamp of when the comment was posted.",
+          "Comment": "Text of the comment.",
+          "Photo": "Photo associated with the comment, if any.",
+          "Url": "URL of the video the comment was posted on."
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**tl;dr:** Charts on big tables were building one `Intl.DateTimeFormat` **per row** (65k rows → +1.7 GB per chart). Hoisting the formatters cuts the consent flow's peak from **4966 MB (v3.0.0) / 4368 MB (after #127) to 839 MB** — first time the flow fits under the iOS kill threshold. Output is byte-identical; 14 new tests include an O(1)-construction tripwire.

Also ships the prevention layer: ADR-0035 (no per-row allocation) with executable grep checks, an ESLint ban in the hot path, and a viz-bearing benchmark config fixture — the bug was invisible until the benchmark config actually had charts on the big table.

## Why

Production profiling of the consent flow with the real study's watch-history charts (65k-row reference DDP, `dd-uu-tiktok-2026`'s exact viz specs) found the chart pipeline allocating gigabytes: `formatDate` constructed **one `Intl.DateTimeFormat` per table row** in the `*_cycle` branches, and the `month`/`day`/`hour` branches did the same in disguise via per-row `toLocaleString`. Microbenchmark: 65k per-row constructions = **+1697 MB RSS**; a single hoisted formatter = **+0 MB** (ICU native memory, largely unrecovered by GC).

Measured impact on the full flow (250 ms RSS sampling, production builds inside mono, app renderer process):

| build | peak | after charts settle |
|---|---|---|
| v3.0.0 | **4966 MB**, sustained until flow end | ~4.9 GB retained |
| + #122 fixes (PR #127) | 4368 MB transient | 1013 MB |
| + this PR | **839 MB** | — (peak is now extract/donate, charts ≈ free) |

The two stacked bugs together are the likely mechanism behind iPhone participants losing donations mid-consent (iOS jetsam kills ~1–1.5 GB instantaneous): PR #127 made the 4.9 GB ownership graph transient; this PR removes the remaining ~3.5 GB compute burst. **6× total.**

Neither bug was visible earlier because the benchmark/profiling configs attached visualizations only to small tables — the entire chart pipeline was invisible to measurement until the config matched the study.

## What

- **`util.ts` (`formatDate`)**: hoist all five ICU formatter constructions out of the per-row closures; replace per-row `toLocaleString` with hoisted `Intl.DateTimeFormat`  (`toLocaleString(locale, opts)` ≡ `new Intl.DateTimeFormat(locale, opts).format()` per  ECMA-402, so output is byte-identical — verified per branch against fixture dates).
- **`formatDate.test.ts`** (new, 14 tests): output equivalence per format (locale-variant expectations computed via the same Intl calls, not hardcoded) + a construction-count spy tripwire on all five hoisted branches (O(1) per call; read ~1014/1008/1025 constructions per 1000 rows against the old code).

**Guardrails against the class**, not just this instance:

- **ADR-0035** — "Per-row work over participant tables must not allocate": routed to all of `consent_form_viz/**` (brief fires on parse/serialize/search/display edits), with three executable grep checks (`adg lean check`, pre-commit + CI): `toLocaleString` banned in the per-row pipeline dir, `new Intl.` banned tree-wide outside `util.ts`, no zod parsing inside the pipeline (validation stays at the table boundary). `toLocaleString` keeps its legitimate O(1) count-label uses in `table.tsx`/`table_items.tsx` (display path verified: pre-stringified cells, 7-row pagination).
- **ADR-0032** — two `expect: present` sentinel checks so the #122 core (column projection before `postMessage`, worker termination) can't be silently removed.
- **ADR-0034** — guidance now requires a viz-bearing config for benchmark builds, pointing at the new fixture.
- **ESLint** (flat-config override, pipeline dir): `toLocaleString*`/`new Intl.*` → error with the ADR-0035 message; `util.ts` and tests carved out. Adds the missing `@eslint/js` devDependency (the config imported it but it was never declared — lint was unrunnable in this package) and a `lint` script. 118 pre-existing lint errors in unrelated files left untouched.
- **`scripts/benchmarks/fixtures/tiktok_config.with-watchviz.json`** + README methodology section: the peak harness only exercises the chart pipeline if the built config attaches visualizations to the big table.

All five grep checks and the ESLint rule were negative-tested (planted violation → check fails → removed → clean).

## Test evidence

data-collector jest 26/26 (12 pre-existing + 14 new) · `pnpm build` clean
`adg lean index` 35 records, 0 failures/warnings · `adg lean check` 19/19
production A/B runs above (methodology per `scripts/benchmarks/README.md`).

## Notes

- The study fork `dd-uu-tiktok-2026` carries its own copies of both bugs and should pull PR #127 + this PR; its participants currently hit the worst case measured here.
- Related follow-ups tracked in `PENDING_ISSUES.md`: donation-path payload logging (`py_worker.js`, measured +40 MB console growth at donate), production-build benchmark sink, worker-concurrency bound / columnar table representation (ADR-0035 names columnar as the structural end-state).