### PR TITLE
Feature: Align with Eyra on the locale handling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Earlier releases used sequential numbering (#1-#5) matching the upstream
 
 ### Fixed
 
+* Translation resolution no longer returns `undefined` or throws on a
+  malformed bundle: `translator.ts` and `text_bundle.ts` now resolve
+  exact locale → default locale → first available translation →
+  the `'?text?'` sentinel, with `typeof`/null-safe guards throughout
+  (#112).
+* The participant-facing UI locale now reaches Python. `firstRunCycle`
+  threads `platform` as an explicit prop (`App.tsx` →
+  `ScriptHostComponent` → `Assembly` → `WorkerProcessingEngine`) and
+  posts a `data: {sessionId, locale, platform}` context (upstream
+  #960 shape); `main.py`'s `start` reads the dict and stores the
+  locale via the new
+  `port.helpers.ui_locale` (`get_ui_locale`/`set_ui_locale`, default
+  `"en"`), which platform code reads instead of widening
+  `module.process(session_id)` (ADR-0029) (#124).
 * Donations are no longer silently fire-and-forget on any deployment.
   `LiveBridge.send()` now always awaits the host's
   `DonateSuccess`/`DonateError` reply, so a failed upload reliably
@@ -51,6 +65,14 @@ Earlier releases used sequential numbering (#1-#5) matching the upstream
   awaited donation never settles, and the participant waits on a
   spinner indefinitely. Deploying against a pre-February-2026 mono
   image is unsupported.
+* All `import.meta` reads in `packages/feldspar`. The package now
+  contains no `import.meta` and no `VITE_*` read, matching upstream
+  `eyra/feldspar` (the one `process.env.NODE_ENV` read in
+  `script_host_component.tsx` is upstream's own and stays):
+  `VITE_PLATFORM` is read once in `App.tsx` and travels onward only as
+  a prop, and a bundle built without a platform fails loudly via
+  `script.py`'s `ValueError` on the consent-gated error page rather
+  than falling back to a build-time default.
 
 ## v3.0.0 — 2026-07-16
 

--- a/docs/decisions/0004-per-platform-release-builds-via-vite-platform.md
+++ b/docs/decisions/0004-per-platform-release-builds-via-vite-platform.md
@@ -9,6 +9,9 @@ category: Fork governance
 applies_to:
     - release.sh
     - check-deps.sh
+    - packages/data-collector/src/App.tsx
+    - packages/feldspar/src/components/script_host_component.tsx
+    - packages/feldspar/src/framework/assembly.ts
     - packages/feldspar/src/framework/processing/worker_engine.ts
     - packages/data-collector/public/py_worker.js
     - packages/python/port/main.py
@@ -27,15 +30,16 @@ checks:
 
 ## Decision
 
-Per-platform deployment builds are produced by `release.sh`, which loops setting `VITE_PLATFORM` over the platforms discovered by globbing `packages/python/port/configs/*_config.json`, threading one build-time env var from the build through the worker to the Python layer. Researcher forks run `release.sh` to produce their own deployment zips.
+Per-platform deployment builds are produced by `release.sh`, which loops setting `VITE_PLATFORM` over the platforms discovered by globbing `packages/python/port/configs/*_config.json`. `App.tsx` reads that env var once and threads it onward as an explicit `platform` prop through the worker to Python — the prop chain is the only source. Researcher forks run `release.sh` to produce their own deployment zips.
 
 ## Guidance
 
 - Produce deployable per-platform zips with `release.sh` (one per platform); don't add runtime platform detection in Python — `VITE_PLATFORM` is fixed at build time.
 - The platform list is derived from `configs/`: adding a platform to a release means generating its config (`pnpm generate-config <platform>`), never editing a hardcoded list in `release.sh`.
-- Preserve the `VITE_PLATFORM` thread — `release.sh → worker_engine.ts → py_worker.js → main.py → script.py` — when touching any of those files. `VITE_PLATFORM` is required — `check-deps.sh` guards dev mode, and a bundle built without a platform is *invalid*: it must fail explicitly (build-time refusal, or a clear participant-facing message), never an unhandled traceback.
+- Preserve the platform thread — `release.sh → App.tsx (\`VITE_PLATFORM\` read) → ScriptHostComponent \`platform\` prop → Assembly → WorkerProcessingEngine → py_worker.js \`data\` ctx → main.py \`start\` → script.py` — when touching any of those files. `App.tsx`'s `platform={import.meta.env.VITE_PLATFORM}` is the thread's single sanctioned origin — the one intentional first-party env read, substituted in both dev and build. Downstream of `App.tsx` the value travels only by prop and constructor argument: no layer re-reads the environment, and there is no fallback if the prop is absent. `packages/feldspar` contains no `import.meta` and no `VITE_*` read at all, matching upstream `eyra/feldspar` (its one `process.env.NODE_ENV` read in `script_host_component.tsx` is identical to upstream's own and is not part of this thread).
+- `VITE_PLATFORM` is required — `check-deps.sh` guards dev mode, and a bundle built without a platform is *invalid*: it must fail explicitly, never an unhandled traceback. The explicit failure is `script.py`'s `if not platform: raise ValueError(...)`, raised on the generator's first `send()` so `ScriptWrapper` turns it into the consent-gated error page. Don't paper over a missing platform with a default anywhere along the thread.
 - Don't reintroduce the removed Earthly build pipeline (`_build_release.yml`, `forbids`); `gh-pages.yml` validates the template build. (The separate `release.yml` — a GitHub release on a `v*` tag from CHANGELOG — is unrelated to per-platform deployment.)
 
 ## Why
 
-Eyra Next deploys one workflow instance per platform — its own assignment, its own uploaded zip — so a single multi-platform bundle cannot be deployed, and Python needs the platform identity to pick extraction logic. One build-time env var is the simplest mechanism that works without CI (releases run locally; the Earthly pipeline this replaced was long dead). A runtime selector was rejected: nothing at runtime should decide what a deployed study extracts. Deriving the platform list from `configs/` fixed the drifted hardcoded list — generating a config is now the single registration step. Costs: N builds per release, N hand-maintained config files, and the scheme rests on the invalid-build contract — an unset-platform bundle (`platform: void 0` from the script builder) must fail loudly, not show a participant a traceback.
+Eyra Next deploys one workflow instance per platform — its own assignment, its own uploaded zip — so a single multi-platform bundle cannot be deployed, and Python needs the platform identity to pick extraction logic. One build-time env var is the simplest mechanism that works without CI (releases run locally; the Earthly pipeline this replaced was long dead). A runtime selector was rejected: nothing at runtime should decide what a deployed study extracts. Deriving the platform list from `configs/` fixed the drifted hardcoded list — generating a config is now the single registration step. Threading `platform` as an explicit prop from a single env read (rather than letting every layer re-read the environment) makes the value host-configurable and testable without a real Vite build, and keeps `packages/feldspar` env-free so it stays mergeable with upstream; a second, lower-precedence env read would only hide a broken thread behind a stale build-time value. Costs: N builds per release, N hand-maintained config files; and the scheme still rests on the invalid-build contract — an unset-platform bundle must fail loudly, not show a participant a traceback.

--- a/docs/decisions/0037-resolve-text-to-exact-default-first-available-or-sentinel.md
+++ b/docs/decisions/0037-resolve-text-to-exact-default-first-available-or-sentinel.md
@@ -1,0 +1,45 @@
+---
+status: accepted
+date: "2026-08-05"
+tags:
+    - translation
+    - locale
+    - i18n
+source: docs/superpowers/plans/2026-08-05-locale-translation-consolidation.md (Stage 1, Task 8)
+category: Localization
+applies_to:
+    - packages/feldspar/src/framework/translator.ts
+    - packages/feldspar/src/framework/text_bundle.ts
+    - packages/feldspar/src/components/script_host_component.tsx
+    - packages/feldspar/src/framework/processing/worker_engine.ts
+    - packages/data-collector/public/py_worker.js
+    - packages/python/port/main.py
+    - packages/python/port/helpers/ui_locale.py
+priority: invariant
+companions:
+    - packages/feldspar/src/framework/translator.test.ts
+    - packages/feldspar/src/framework/text_bundle.test.ts
+    - packages/python/tests/test_ui_locale.py
+---
+
+# Resolve text to exact, default, first-available, or sentinel
+
+## Decision
+
+`Translator.translate` is the sole production resolution path, falling through exact-locale match → `Translator`'s host-configurable default locale (`setDefaultLocale`; `ScriptHostComponent`'s `defaultLocale` prop) → first available translation → the `MISSING_TRANSLATION` sentinel (`'?text?'`), with `resolve()` never returning `undefined`. `TextBundle.resolve` mirrors the same chain but is test-/upstream-parity-only — no production caller reaches it directly.
+
+## Guidance
+
+- New text-resolving code must keep `resolve()`'s chain total — exact → `defaultLocale` → first available → `'?text?'` sentinel, never `undefined` — guarding with `typeof text === 'string'` checks and null-safe `?.`/`?? {}` access, matching `translator.ts`. `translate()`'s `TypeError` on non-string/non-`Translatable` input is separate entry-point junk-guarding, not part of the total chain (Stage 2 owns hardening that boundary further).
+- The host-configurable default locale governs `Translator` only, via `ScriptHostComponent`'s `defaultLocale` prop (`Translator.setDefaultLocale`); don't add a second hardcoded fallback elsewhere. `TextBundle`'s own `defaultLocale` field is a separate, hardcoded `'nl'` value that no production code ever sets — it is not a second host-configured path.
+- UI locale rides the `firstRunCycle` `data` dict (`{sessionId, locale, platform}`) into Python via `main.py`'s `start`, which stores it with `ui_locale.set_ui_locale`. Platform code reads it only through `ui_locale.get_ui_locale()` (default `"en"`) — never widen `module.process(session_id)`'s signature to take a locale (cross-ref ADR-0029's platform-dispatch contract).
+- `ui_locale.py`'s UI locale is a distinct concept from `helpers/validate.py`'s DDP-export `Language` enum (parsing language of exported data) — the two must never be synced or conflated.
+
+## Why
+
+Malformed or partial translation bundles are routine (a platform config missing a locale, UI text authored in only one language) — participant-facing UI must never blank out or crash on a missing key mid-flow, so the resolver is defined as total (always returns a displayable string) rather than partial, with the sentinel as a visible-but-safe last resort. Centralizing the fallback chain in one place, rather than each caller null-checking its own bundle, keeps behavior consistent across the UI and the visualization layer. Keeping UI locale (a rendering choice) separate from Python's file-parsing language enum prevents a Python change from silently altering what language the frontend renders in, or vice versa.
+
+## Checks
+
+- Confirm `translator.ts`'s `resolve` and `text_bundle.ts`'s `resolve` never have a code path returning `undefined`: every branch ends in a `typeof === 'string'` return or the `MISSING_TRANSLATION` sentinel.
+- Confirm `main.py`'s `start` calls `ui_locale.set_ui_locale` before delegating to `process()` and that `process(session_id)` itself takes no locale argument.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -67,3 +67,7 @@ Load the ADR(s) whose filename matches the area you are touching.
 ### Architecture
 
 - [0036 — Await the host's donation acknowledgment before resolving](./0036-await-the-host-s-donation-acknowledgment-before-resolving.md)
+
+### Localization
+
+- [0037 — Resolve text to exact, default, first-available, or sentinel](./0037-resolve-text-to-exact-default-first-available-or-sentinel.md)

--- a/packages/data-collector/public/py_worker.js
+++ b/packages/data-collector/public/py_worker.js
@@ -12,12 +12,15 @@ onmessage = (event) => {
       });
       break;
 
-    case "firstRunCycle":
-      const platform = event.data.platform;
-      const pyPlatform = (platform && platform !== "undefined") ? `"${platform}"` : "None";
-      pyScript = self.pyodide.runPython(`port.start(${event.data.sessionId}, ${pyPlatform})`);
+    case "firstRunCycle": {
+      const ctx = event.data.data;
+      // strip null/undefined/"undefined": the JSON text is interpolated as a Python
+      // literal and values must stay strings/numbers (JSON null is not Python)
+      for (const k of Object.keys(ctx)) if (ctx[k] == null || ctx[k] === "undefined") delete ctx[k];
+      pyScript = self.pyodide.runPython(`port.start(${JSON.stringify(ctx)})`);
       runCycle(null);
       break;
+    }
 
     case "nextRunCycle":
       const { response } = event.data;

--- a/packages/data-collector/src/App.tsx
+++ b/packages/data-collector/src/App.tsx
@@ -12,6 +12,8 @@ function App() {
         workerUrl="./py_worker.js"
         standalone={import.meta.env.DEV}
         logLevel={import.meta.env.DEV ? "debug" : "info"}
+        platform={import.meta.env.VITE_PLATFORM}
+        defaultLocale="en"
         factories={[
           new DataSubmissionPageFactory({
             promptFactories: [

--- a/packages/feldspar/src/components/script_host_component.tsx
+++ b/packages/feldspar/src/components/script_host_component.tsx
@@ -10,23 +10,28 @@ import {
 } from "../framework/visualization/react/context";
 import { PageFactory } from "../framework/visualization/react/factories/base";
 import { LogLevel } from "../framework/logging";
+import { Translator } from "../framework/translator";
 
 export interface ScriptHostProps {
   workerUrl: string;
   locale?: string;
+  defaultLocale?: string;
   standalone?: boolean;
   className?: string;
   factories?: PageFactory[];
   logLevel?: LogLevel;
+  platform?: string;
 }
 
 const FeldsparContent: React.FC<ScriptHostProps> = ({
   workerUrl,
   locale = "en",
+  defaultLocale,
   standalone = false,
   className,
   factories = [],
   logLevel = "info",
+  platform,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const assemblyRef = useRef<Assembly | null>(null);
@@ -40,7 +45,8 @@ const FeldsparContent: React.FC<ScriptHostProps> = ({
     workerRef.current = worker;
 
     const run = (bridge: Bridge, selectedLocale: string = locale) => {
-      const assembly = new Assembly(worker, bridge, factories, logLevel);
+      if (defaultLocale != null) Translator.setDefaultLocale(defaultLocale);
+      const assembly = new Assembly(worker, bridge, selectedLocale, factories, logLevel, platform);
       assembly.visualizationEngine.start(
         containerRef.current!,
         selectedLocale,
@@ -81,7 +87,7 @@ const FeldsparContent: React.FC<ScriptHostProps> = ({
         }
       }, 0);
     };
-  }, [workerUrl, locale, standalone, setState, factories, logLevel]);
+  }, [workerUrl, locale, defaultLocale, standalone, setState, factories, logLevel, platform]);
 
   return (
     <div ref={containerRef} className={className}>

--- a/packages/feldspar/src/framework/assembly.ts
+++ b/packages/feldspar/src/framework/assembly.ts
@@ -13,13 +13,13 @@ export default class Assembly {
   logForwarder: LogForwarder
   windowLogSource: WindowLogSource
 
-  constructor(worker: Worker, bridge: Bridge, factories: PageFactory[] = [], logLevel: LogLevel = 'warn') {
+  constructor(worker: Worker, bridge: Bridge, locale: string = "en", factories: PageFactory[] = [], logLevel: LogLevel = 'warn', platform?: string) {
     const sessionId = String(Date.now())
     const visualizationFactory = new ReactFactory(factories);
     this.visualizationEngine = new ReactEngine(visualizationFactory);
     this.router = new CommandRouter(bridge, this.visualizationEngine)
     this.logForwarder = new LogForwarder((entries) => bridge.sendLogs(entries), logLevel)
     this.windowLogSource = new WindowLogSource(this.logForwarder)
-    this.processingEngine = new WorkerProcessingEngine(sessionId, worker, this.router, this.logForwarder)
+    this.processingEngine = new WorkerProcessingEngine(sessionId, locale, worker, this.router, this.logForwarder, platform)
   }
 }

--- a/packages/feldspar/src/framework/processing/worker_engine.test.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.test.ts
@@ -1,0 +1,31 @@
+import WorkerProcessingEngine from './worker_engine'
+import { CommandHandler } from '../types/modules'
+
+const commandHandler: CommandHandler = {
+  onCommand: jest.fn(),
+}
+
+describe('WorkerProcessingEngine', () => {
+  it('posts the #960 data dict with sessionId, locale, and platform', () => {
+    const worker = { postMessage: jest.fn(), onmessage: null } as any
+    const engine = new WorkerProcessingEngine('123', 'nl', worker, commandHandler, undefined, 'example')
+    engine.firstRunCycle()
+    expect(worker.postMessage).toHaveBeenCalledWith({
+      eventType: 'firstRunCycle',
+      data: { sessionId: '123', locale: 'nl', platform: 'example' },
+    })
+  })
+
+  // The platform prop is the only source (ADR-0004): with no platform argument the
+  // handshake carries `undefined`, and the Python layer raises — nothing substitutes
+  // a value here.
+  it('sends an undefined platform when the constructor was given none', () => {
+    const worker = { postMessage: jest.fn(), onmessage: null } as any
+    const engine = new WorkerProcessingEngine('123', 'nl', worker, commandHandler, undefined)
+    engine.firstRunCycle()
+    expect(worker.postMessage).toHaveBeenCalledWith({
+      eventType: 'firstRunCycle',
+      data: { sessionId: '123', locale: 'nl', platform: undefined },
+    })
+  })
+})

--- a/packages/feldspar/src/framework/processing/worker_engine.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.ts
@@ -4,23 +4,29 @@ import { Logger } from '../logging'
 
 export default class WorkerProcessingEngine {
   sessionId: String
+  locale: String
   worker: Worker
   commandHandler: CommandHandler
   logger?: Logger
+  platform?: string
 
   resolveInitialized!: () => void;
   resolveContinue!: () => void;
 
   constructor (
     sessionId: string,
+    locale: string,
     worker: Worker,
     commandHandler: CommandHandler,
-    logger?: Logger
+    logger?: Logger,
+    platform?: string
   ) {
     this.sessionId = sessionId
+    this.locale = locale
     this.commandHandler = commandHandler
     this.worker = worker
     this.logger = logger
+    this.platform = platform
     this.initWorkerEventHandlers()
   }
 
@@ -98,14 +104,16 @@ export default class WorkerProcessingEngine {
     })
   }
 
-  firstRunCycle(): void {
-    const meta: any = import.meta;
-    const platform = meta.env.VITE_PLATFORM;
+  // `platform` arrives only through the constructor — App.tsx is the single source
+  // (ADR-0004). There is no env fallback here: feldspar reads no build-time env of
+  // its own, and a bundle built without a platform must fail loudly in Python
+  // (script.py raises ValueError, surfaced through the consent-gated error page)
+  // rather than be papered over by a default chosen down here.
+  firstRunCycle (): void {
     this.worker.postMessage({
-      eventType: "firstRunCycle",
-      sessionId: this.sessionId,
-      platform,
-    });
+      eventType: 'firstRunCycle',
+      data: { sessionId: this.sessionId, locale: this.locale, platform: this.platform },
+    })
   }
 
   nextRunCycle (response: Response): void {

--- a/packages/feldspar/src/framework/text_bundle.test.ts
+++ b/packages/feldspar/src/framework/text_bundle.test.ts
@@ -1,0 +1,59 @@
+import TextBundle from './text_bundle'
+import { MISSING_TRANSLATION } from './translator'
+
+describe('TextBundle.resolve', () => {
+  let bundle: TextBundle
+
+  beforeEach(() => {
+    bundle = new TextBundle()
+  })
+
+  it('returns exact-hit translation for requested locale', () => {
+    bundle.add('en', 'Hello')
+    bundle.add('nl', 'Hallo')
+    expect(bundle.resolve('en')).toBe('Hello')
+  })
+
+  it('returns empty-string as valid translation (not a fallback trigger)', () => {
+    bundle.add('en', '')
+    bundle.add('nl', 'Hallo')
+    expect(bundle.resolve('en')).toBe('')
+  })
+
+  it('falls back to defaultLocale when requested locale missing', () => {
+    bundle.add('nl', 'Hallo')
+    bundle.add('es', 'Hola')
+    expect(bundle.resolve('en')).toBe('Hallo')
+  })
+
+  it('returns first available translation when both locale and defaultLocale missing', () => {
+    bundle.add('es', 'Hola')
+    bundle.add('fr', 'Bonjour')
+    // Should return one of the available translations (order depends on Object.values)
+    const result = bundle.resolve('en')
+    expect(['Hola', 'Bonjour']).toContain(result)
+  })
+
+  it('returns MISSING_TRANSLATION sentinel when translations empty', () => {
+    expect(bundle.resolve('en')).toBe(MISSING_TRANSLATION)
+  })
+
+  it('translate method escapes the resolved text', () => {
+    bundle.add('en', '<script>alert("xss")</script>')
+    const result = bundle.translate('en')
+    expect(result).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;')
+  })
+
+  it('handles defaultLocale field override', () => {
+    bundle.defaultLocale = 'es'
+    bundle.add('es', 'Hola')
+    bundle.add('nl', 'Hallo')
+    expect(bundle.resolve('en')).toBe('Hola')
+  })
+
+  it('prefers exact locale match over defaultLocale', () => {
+    bundle.add('en', 'Hello')
+    bundle.add('nl', 'Hallo')
+    expect(bundle.resolve('en')).toBe('Hello')
+  })
+})

--- a/packages/feldspar/src/framework/text_bundle.ts
+++ b/packages/feldspar/src/framework/text_bundle.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import { Translatable } from './types/elements'
+import { MISSING_TRANSLATION } from './translator'
 
 export default class TextBundle implements Translatable {
   translations: { [key: string]: string } = {}
@@ -16,19 +17,20 @@ export default class TextBundle implements Translatable {
 
   resolve (locale: string): string {
     const text = this.translations[locale]
-    if (text !== null) {
+    if (typeof text === 'string') {
       return text
     }
 
     const defaultText = this.translations[this.defaultLocale]
-    if (defaultText !== null) {
+    if (typeof defaultText === 'string') {
       return defaultText
     }
 
-    if (Object.values(this.translations).length > 0) {
-      return Object.values(this.translations)[0]
+    const first = Object.values(this.translations).find((value) => typeof value === 'string')
+    if (first !== undefined) {
+      return first
     }
 
-    return '?text?'
+    return MISSING_TRANSLATION
   }
 }

--- a/packages/feldspar/src/framework/translator.test.ts
+++ b/packages/feldspar/src/framework/translator.test.ts
@@ -1,0 +1,31 @@
+import { Translator, MISSING_TRANSLATION } from './translator'
+
+const bundle = (t: Record<string, string>) => ({ translations: t })
+
+describe('Translator.resolve chain', () => {
+  afterEach(() => Translator.setDefaultLocale('nl'))
+  it('returns exact locale match', () =>
+    expect(Translator.translate(bundle({ en: 'Hi', nl: 'Hoi' }), 'nl')).toBe('Hoi'))
+  it('falls back to default locale on missing key (the #112 regression)', () =>
+    expect(Translator.translate(bundle({ nl: 'Hoi' }), 'es')).toBe('Hoi'))
+  it('setDefaultLocale changes the fallback (en-first)', () => {
+    Translator.setDefaultLocale('en')
+    expect(Translator.translate(bundle({ en: 'Hi', nl: 'Hoi' }), 'de')).toBe('Hi')
+  })
+  it('en-only bundle under nl returns English, not blank (questionnaire bug)', () => {
+    Translator.setDefaultLocale('en')
+    expect(Translator.translate(bundle({ en: 'Continue' }), 'nl')).toBe('Continue')
+  })
+  it('empty string is a hit, not a miss (netflix contract)', () =>
+    expect(Translator.translate(bundle({ en: '', nl: '' }), 'en')).toBe(''))
+  it('first available when default locale absent', () =>
+    expect(Translator.translate(bundle({ ro: 'Salut' }), 'es')).toBe('Salut'))
+  it('sentinel on empty translations', () =>
+    expect(Translator.translate(bundle({}), 'es')).toBe(MISSING_TRANSLATION))
+  it('never returns undefined for any miss', () =>
+    expect(typeof Translator.translate(bundle({ nl: 'x' }), 'zz')).toBe('string'))
+  it('plain string passes through', () =>
+    expect(Translator.translate('literal', 'es')).toBe('literal'))
+  it('null translations object yields sentinel, not throw', () =>
+    expect(Translator.translate({ translations: null as any }, 'en')).toBe(MISSING_TRANSLATION))
+})

--- a/packages/feldspar/src/framework/translator.ts
+++ b/packages/feldspar/src/framework/translator.ts
@@ -1,7 +1,13 @@
 import { isTranslatable, Text, Translatable } from './types/elements'
 
+export const MISSING_TRANSLATION = '?text?'
+
 export const Translator = (function () {
-  const defaultLocale: string = 'nl'
+  let defaultLocale: string = 'nl'
+
+  function setDefaultLocale (locale: string): void {
+    defaultLocale = locale
+  }
 
   function translate (text: Text, locale: string): string {
     if (typeof text === 'string') {
@@ -14,24 +20,21 @@ export const Translator = (function () {
   }
 
   function resolve (translatable: Translatable, locale: string): string {
-    const text = translatable.translations[locale]
-    if (text !== null) {
+    const translations = translatable?.translations ?? {}
+    const text = translations[locale]
+    if (typeof text === 'string') {
       return text
     }
-
-    const defaultText = translatable.translations[defaultLocale]
-    if (defaultText !== null) {
+    const defaultText = translations[defaultLocale]
+    if (typeof defaultText === 'string') {
       return defaultText
     }
-
-    if (Object.values(translatable.translations).length > 0) {
-      return Object.values(translatable.translations)[0]
+    const first = Object.values(translations).find((value) => typeof value === 'string')
+    if (first !== undefined) {
+      return first
     }
-
-    return '?text?'
+    return MISSING_TRANSLATION
   }
 
-  return {
-    translate
-  }
+  return { translate, setDefaultLocale }
 })()

--- a/packages/feldspar/src/index.ts
+++ b/packages/feldspar/src/index.ts
@@ -11,7 +11,7 @@ export {ReactFactoryContext} from './framework/visualization/react/factory'
 
 // D3I additions to the upstream feldspar exports
 export { default } from './framework/text_bundle'
-export { Translator } from './framework/translator'
+export { Translator, MISSING_TRANSLATION } from './framework/translator'
 export { Table } from './framework/types/commands'
 export {
   Title1,

--- a/packages/python/port/helpers/ui_locale.py
+++ b/packages/python/port/helpers/ui_locale.py
@@ -1,0 +1,19 @@
+"""Session-fixed UI locale received from the host via port.start.
+
+This is the locale the participant-facing UI renders in, set once per
+session from the #960-shaped context (`port.start({"sessionId", "locale",
+"platform"})`). It is unrelated to `helpers.validate.Language` — the DDP
+*export* language enum used when parsing a participant's exported data —
+and the two must never be synced or conflated.
+"""
+DEFAULT_UI_LOCALE = "en"
+_current: str = DEFAULT_UI_LOCALE
+
+
+def set_ui_locale(raw) -> None:
+    global _current
+    _current = raw if isinstance(raw, str) and raw else DEFAULT_UI_LOCALE
+
+
+def get_ui_locale() -> str:
+    return _current

--- a/packages/python/port/main.py
+++ b/packages/python/port/main.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 
 from port.api.commands import CommandSystemExit, CommandUIRender, CommandSystemDonate
 from port.api.file_utils import AsyncFileAdapter
+from port.helpers import ui_locale
 from port.script import process
 import port.api.props as props
 
@@ -89,6 +90,16 @@ class ScriptWrapper(Generator):
         raise StopIteration
 
 
-def start(sessionId, platform):
-    script = process(sessionId, platform)
+def start(data):
+    """Entry from py_worker.js.
+
+    `data` is the #960-style context dict {"sessionId", "locale", "platform"}
+    posted by WorkerProcessingEngine.firstRunCycle. sessionId arrives as a JSON
+    string (Assembly builds it with String(Date.now())), so downstream
+    donation-key logic (ADR-0020) always sees str.
+    """
+    session_id = data.get("sessionId")
+    platform = data.get("platform")
+    ui_locale.set_ui_locale(data.get("locale"))
+    script = process(session_id, platform)
     return ScriptWrapper(script, platform=platform)

--- a/packages/python/tests/test_main_queue.py
+++ b/packages/python/tests/test_main_queue.py
@@ -75,5 +75,5 @@ def test_start_function_creates_wrapper(monkeypatch):
     monkeypatch.setattr("port.main.process", fake_process)
 
     from port.main import start
-    wrapper = start("session123", "LinkedIn")
+    wrapper = start({"sessionId": "session123", "platform": "LinkedIn"})
     assert isinstance(wrapper, ScriptWrapper)

--- a/packages/python/tests/test_main_start.py
+++ b/packages/python/tests/test_main_start.py
@@ -1,0 +1,56 @@
+"""
+Tests for port.main.start — the entry point invoked by py_worker.js.
+
+The engine calls it with a single #960-shaped context dict
+{"sessionId", "platform", "locale"}.
+
+`start()` delegates to `process()`, which imports platform modules and
+validates configs — to keep this test hermetic we monkeypatch
+`port.main.process` with a stub generator recording the args it received.
+"""
+import pytest
+
+from port.main import start
+from port.helpers import ui_locale
+
+
+@pytest.fixture(autouse=True)
+def reset_ui_locale():
+    ui_locale.set_ui_locale(None)
+    yield
+    ui_locale.set_ui_locale(None)
+
+
+@pytest.fixture
+def recording_process(monkeypatch):
+    """Stub for port.script.process that records its call args."""
+    calls = []
+
+    def fake_process(session_id, platform):
+        # Record eagerly (matches process()'s real call signature); return a
+        # generator so ScriptWrapper's generator-protocol usage still works.
+        calls.append((session_id, platform))
+
+        def gen():
+            yield
+
+        return gen()
+
+    monkeypatch.setattr("port.main.process", fake_process)
+    return calls
+
+
+def test_extracts_session_platform_locale(recording_process):
+    wrapper = start({"sessionId": "abc123", "platform": "example", "locale": "nl"})
+
+    assert recording_process[0] == ("abc123", "example")
+    assert wrapper.platform == "example"
+    assert ui_locale.get_ui_locale() == "nl"
+
+
+def test_missing_locale_defaults_en(recording_process):
+    wrapper = start({"sessionId": "abc123", "platform": "example"})
+
+    assert recording_process[0] == ("abc123", "example")
+    assert wrapper.platform == "example"
+    assert ui_locale.get_ui_locale() == "en"

--- a/packages/python/tests/test_ui_locale.py
+++ b/packages/python/tests/test_ui_locale.py
@@ -1,0 +1,45 @@
+"""
+Tests for the session-fixed UI locale helper (port.helpers.ui_locale).
+
+This locale is received once from the host via port.start's #960-shaped
+context dict and is unrelated to helpers.validate.Language, which governs
+the language of DDP *export* content, not the participant UI.
+"""
+import pytest
+
+from port.helpers import ui_locale
+
+
+@pytest.fixture(autouse=True)
+def reset_ui_locale():
+    """Reset module-level state before and after each test."""
+    ui_locale.set_ui_locale(None)
+    yield
+    ui_locale.set_ui_locale(None)
+
+
+def test_default_locale_is_en():
+    assert ui_locale.get_ui_locale() == "en"
+
+
+def test_set_and_get_locale():
+    ui_locale.set_ui_locale("nl")
+    assert ui_locale.get_ui_locale() == "nl"
+
+
+def test_set_none_defaults_to_en():
+    ui_locale.set_ui_locale("nl")
+    ui_locale.set_ui_locale(None)
+    assert ui_locale.get_ui_locale() == "en"
+
+
+def test_set_empty_string_defaults_to_en():
+    ui_locale.set_ui_locale("nl")
+    ui_locale.set_ui_locale("")
+    assert ui_locale.get_ui_locale() == "en"
+
+
+def test_set_non_string_defaults_to_en():
+    ui_locale.set_ui_locale("nl")
+    ui_locale.set_ui_locale(123)
+    assert ui_locale.get_ui_locale() == "en"


### PR DESCRIPTION
This is a PR that brings in the changes that we deferred at the last upstream sync. It's about establishing the boundary between Next's locale setting and what we take into the feldspar/data-donation-task side so that we can use it for providing the translations we show to users. 

What's in here:

* A fix for the dead translation fallback chain -- this is actually pretty important because right now if someone selects anything other than English or Dutch in Next and then loads our data-donation-task, then it just crashes at the consent page. I reproduced this, dunno how long it's been an issue though.

* The locale is now passed through into Python (this uses Eyra's #960 data dict merged with the fork's platform field. This closes #124 .
* Which platform is running is now read by App.tsx. This is a fix for dev mode, where the aliased read inside feldspar was undefined and killed every session. So this brings us back to removing import.meta so that we match upstream.
* 20 unit tests and docs. 