### PR TITLE
fix(py): all the ways a participant can exit that aren't completion a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,29 @@ Earlier releases used sequential numbering (#1-#5) matching the upstream
   against the `e2etest` fault-injection platform
   (`VITE_PLATFORM=e2etest pnpm test:e2e`).
 
+* **Graceful dead-ends no longer complete the task either.** Cancelling at
+  the file picker, declining the retry prompt after an invalid file, a
+  rejected upload (too large / chunked export), and a failed donation
+  delivery previously exhausted the flow into exit 0 — a green checkmark in
+  Next with no data donated. `FlowBuilder.start_flow()` now raises
+  `TaskIncompleteError` on those paths and `ScriptWrapper` shows the
+  task-incomplete page, then exits with the category's fixed code:
+  2 = participant abandoned, 3 = donation delivery failed, 4 = upload
+  rejected (1 remains the unhandled-error exit). Codes are a fork-local
+  convention pending an agreed contract with Eyra — the host only
+  distinguishes 0 from nonzero today. Genuine completions are unchanged:
+  donation success, consent declined (decline record), and a clean
+  no-data-found still exit 0 — but zero tables *with* extraction errors
+  now routes through the consent-gated error flow (exit 1) instead of
+  masquerading as "no data found", closing a gap against ADR-0019's
+  no-data/extraction-bug separation. `TaskIncompleteError` is raised with
+  a reason key and derives its fixed `(code, info)` pair from its own
+  `EXITS` table, so raise sites cannot put arbitrary text on the bridge. **Behavior change for live studies:** participants who
+  previously "finished" via these dead-ends now stay pending and can
+  re-enter the task. See ADR-0039. Covered by a second
+  `tests/error-flow.spec.ts` test (`tests/invalid.zip` fixture) and unit
+  tests in `test_flow_builder.py` / `test_main_queue.py`.
+
 * Translation resolution no longer returns `undefined` or throws on a
   malformed bundle: `translator.ts` and `text_bundle.ts` now resolve
   exact locale → default locale → first available translation →

--- a/docs/decisions/0039-error-flow-exhaustion-exits-nonzero-exit-0-means-completed.md
+++ b/docs/decisions/0039-error-flow-exhaustion-exits-nonzero-exit-0-means-completed.md
@@ -4,26 +4,42 @@ date: "2026-08-27"
 category: Feldspar
 applies_to:
     - packages/python/port/main.py
+    - packages/python/port/helpers/flow_builder.py
 priority: invariant
 companions:
     - packages/python/tests/test_main_queue.py
+    - packages/python/tests/test_flow_builder.py
     - tests/error-flow.spec.ts
+checks:
+    - desc: no interpolated text reaches TaskIncompleteError (reason keys only)
+      grep: 'TaskIncompleteError\(f'
+      in: ["packages/python/port/**/*.py"]
+      expect: absent
+    - desc: the only literal exit code in ScriptWrapper is the flow-end 0
+      grep: 'CommandSystemExit\([1-9]'
+      in: ["packages/python/port/main.py"]
+      expect: absent
+    - desc: the incomplete exit is parameterized from the handler's (code, info)
+      grep: 'CommandSystemExit\(self\._exit_code, self\._exit_info\)'
+      in: ["packages/python/port/main.py"]
+      expect: present
 ---
 
-# Error-flow exhaustion exits nonzero; exit 0 means completed
+# Exit nonzero on every incomplete ending; 0 means completed
 
 ## Decision
 
-The exit code is the completion signal across the bridge: only genuine flow-end exits 0. When the consent-gated error flow (`error_flow()`) exhausts, `ScriptWrapper.send()` returns `CommandSystemExit(1, "Error flow completed")` instead of the flow-end `CommandSystemExit(0, ...)`, so the host keeps an errored participant's task pending rather than recording it as completed.
+The exit code is the completion signal across the bridge: only genuine flow-end exits 0. Every incomplete ending exits nonzero through `ScriptWrapper.send()`, so the host keeps the task pending rather than recording it as completed.
 
 ## Guidance
 
-- Never let the error-handler's `StopIteration` branch in `ScriptWrapper.send()` fall back to exit 0 — hosts (mono's `crew_task_helpers.ex` `handle_tool_exited()`) treat exit 0 as unconditional completion with no donation check, so an error-end exit 0 silently records an errored participant as a satisfied completion.
-- Keep the exit `info` a fixed PII-free literal (`"Error flow completed"`) — never interpolate traceback or exception text into it; that text leaves the iframe only through the consent-gated `error-report` donation inside `error_flow()` (ADR-0022, ADR-0023).
-- `error_flow()` terminates by yielding `ph.render_task_incomplete_page(platform)` (built in `port_helpers.py` per ADR-0009) — a single-button Confirm that resolves so the generator can exhaust. This refines, not contradicts, ADR-0025's no-in-iframe-end-page rule: success still exits through plain generator exhaustion with no terminal page; this page exists only on the error path, as a *resolvable pre-exit acknowledgment* replacing the stale error page the participant would otherwise be stranded on, and it must never become a permanent unresolved end page (an unresolved render promise would suppress the exit signal entirely, reproducing the EndPage hang ADR-0025 forbids).
-- The acceptance test for this behavior is `tests/error-flow.spec.ts` (paired with the `tests/error-trigger.zip` fixture), run via the e2etest platform (`packages/python/port/platforms/e2etest.py`, `VITE_PLATFORM=e2etest pnpm test:e2e`); that platform is build-time-only and excluded from real per-platform releases by `release.sh`'s discovery loop and `scripts/verify_release_wheel.py` (ADR-0004) — it never ships to a study participant.
-- Changing exit-code semantics is a workflow↔host contract change: coordinate with mono and ship it with a version bump and migration notes.
+- A `start_flow()` terminal path that IS a completion (donation success, consent declined with a decline record, no data found with no extraction errors) `return`s; one that is NOT raises `TaskIncompleteError` with a reason from its `EXITS` table — the exception derives the fixed `(code, info)` pair itself, so a raise site can never inject text, and never a `return` that lets an incomplete ending exhaust into exit 0.
+- Never let the handler exhaustion branch in `ScriptWrapper.send()` fall back to exit 0 — hosts (mono's `crew_task_helpers.ex` `handle_tool_exited()`) treat exit 0 as unconditional completion with no donation check, so an incomplete-end exit 0 silently records the participant as a satisfied completion.
+- The exit `info` is always a fixed PII-free literal (`TaskIncompleteError.EXITS`, or `"Error flow completed"`) — never interpolate traceback, exception, or participant text; error detail leaves the iframe only through the consent-gated `error-report` donation inside `error_flow()`.
+- Nonzero codes are a fork-local convention (1 unhandled error, 2 participant abandoned, 3 donation delivery failed, 4 upload rejected) pending an agreed exit-code contract with Eyra: the host only distinguishes 0 from nonzero today, so codes may be re-mapped in coordination with mono, but 0 stays reserved for genuine completion.
+- Both handler flows (`error_flow()` and `incomplete_flow()` in `main.py`) terminate by yielding `ph.render_task_incomplete_page(platform)`, and that page must resolve its render promise so the generator can exhaust — an unresolved terminal page suppresses the exit signal entirely (the EndPage hang). Success paths still end by plain exhaustion with no terminal page.
+- Acceptance tests: `tests/error-flow.spec.ts` (crash path with `tests/error-trigger.zip`; retry-declined path with `tests/invalid.zip`), run via the e2etest platform — `VITE_PLATFORM=e2etest pnpm test:e2e`.
 
 ## Why
 
-Mono completes the crew task on exit 0 without checking that anything was donated, so an error path exiting 0 silently converts errored participants into satisfied completions — invisible in funnel analysis, and completion/payment signals can fire with zero data (Issue #123). Nonzero exit plus a resolvable terminal page fixes both halves: the host sees the task as incomplete, and the participant is not left staring at a stale error page with no way forward.
+Mono completes the crew task on exit 0 without checking that anything was donated, so any incomplete path exiting 0 silently converts errored or abandoning participants into satisfied completions — invisible in funnel analysis, with completion/payment signals firing on zero data (Issue #123).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -21,7 +21,7 @@ Load the ADR(s) whose filename matches the area you are touching.
 - [0006 — Communicate with the host through a swappable Bridge](./0006-communicate-with-the-host-through-a-swappable-bridge.md)
 - [0017 — Worker delivers uploads as PayloadFile, not a WORKERFS path](./0017-worker-delivers-uploads-as-payloadfile-not-a-workerfs-path.md)
 - [0025 — Flow completion is generator exhaustion, not an explicit exit](./0025-flow-completion-is-generator-exhaustion-not-an-explicit-exit.md)
-- [0039 — Error-flow exhaustion exits nonzero; exit 0 means completed](./0039-error-flow-exhaustion-exits-nonzero-exit-0-means-completed.md)
+- [0039 — Exit nonzero on every incomplete ending; 0 means completed](./0039-error-flow-exhaustion-exits-nonzero-exit-0-means-completed.md)
 
 ### Python architecture
 

--- a/packages/python/port/helpers/flow_builder.py
+++ b/packages/python/port/helpers/flow_builder.py
@@ -19,6 +19,31 @@ import port.helpers.uploads as uploads
 logger = logging.getLogger(__name__)
 
 
+class TaskIncompleteError(Exception):
+    """Flow ended without completion. ScriptWrapper maps this to a nonzero
+    exit command so the host keeps the task pending (never completed).
+
+    Raised with a reason key only: the fixed (code, info) pair comes from
+    EXITS, so a raise site can never put exception or participant text on
+    the bridge — exit info crosses it unconsented (ADR-0022/0023). Codes
+    are a fork-local convention pending an agreed exit-code contract with
+    Eyra; the host only distinguishes 0 from nonzero today (see ADR-0039).
+    """
+
+    EXITS = {
+        "abandoned": (2, "Participant abandoned the task"),
+        "donation_failed": (3, "Donation delivery failed"),
+        "upload_rejected": (4, "Upload rejected"),
+    }
+
+    def __init__(self, reason: str):
+        exit_code, exit_info = self.EXITS[reason]
+        super().__init__(exit_info)
+        self.reason = reason
+        self.exit_code = exit_code
+        self.exit_info = exit_info
+
+
 class FlowBuilder:
     def __init__(self, session_id: str, platform_name: str):
         self.session_id = session_id
@@ -65,7 +90,10 @@ class FlowBuilder:
         Control flow rules:
         - continue: retry upload only
         - break: successful extraction, proceed to consent
-        - return: every terminal path
+        - return: terminal paths that ARE completions (exit 0 at the host)
+        - raise TaskIncompleteError: terminal paths that are NOT completions —
+          ScriptWrapper shows the task-incomplete page and exits nonzero so
+          the host keeps the task pending (ADR-0039)
 
         Flow milestones are sent to the host via explicit CommandSystemLog yields
         (through emit_log). These must be PII-free. Local logger keeps full
@@ -88,7 +116,7 @@ class FlowBuilder:
                     "info",
                     f"[{self.platform_name}] Upload skipped: type={file_result.__type__}",
                 )
-                return
+                raise TaskIncompleteError("abandoned")
 
             # AsyncFileAdapter — file-like, passed directly to validators
             # and extractors. Never materialized to a path. See ADR-0026.
@@ -105,7 +133,7 @@ class FlowBuilder:
                 logger.error("Safety check failed for %s: %s", self.platform_name, e)
                 yield from ph.emit_log("info", f"[{self.platform_name}] Safety check failed: {type(e).__name__}")
                 _ = yield ph.render_safety_error_page(self.platform_name, e)
-                return
+                raise TaskIncompleteError("upload_rejected")
 
             # 3. Validate
             validation = self.validate_file(archive)
@@ -125,7 +153,8 @@ class FlowBuilder:
                 retry_result = yield ph.render_page(self.UI_TEXT["retry_header"], retry_prompt)
                 if retry_result.__type__ == "PayloadTrue":
                     continue  # loop back to step 1
-                return  # user declined retry
+                yield from ph.emit_log("info", f"[{self.platform_name}] Retry declined")
+                raise TaskIncompleteError("abandoned")
 
             # 5. Extract
             logger.info("Extracting data for %s", self.platform_name)
@@ -143,8 +172,17 @@ class FlowBuilder:
             else:
                 yield from ph.emit_log("info", f"[{self.platform_name}] Extraction complete: {len(result.tables)} tables, {total_rows} rows; errors: none")
 
-            # 7. If no tables → no-data page
+            # 7. If no tables → no-data page (clean empties only: zero tables
+            # WITH extraction errors is an extraction failure, never presented
+            # as "no data found" — the no-data/extraction-bug separation in
+            # the no-data ADR. Raising routes it through the consent-gated
+            # error flow, so the participant stays pending.)
             if not result.tables:
+                if result.errors:
+                    raise RuntimeError(
+                        f"Extraction produced no tables with errors: "
+                        f"{', '.join(f'{k}×{v}' for k, v in result.errors.items())}"
+                    )
                 logger.info("No data extracted for %s", self.platform_name)
                 _ = yield ph.render_no_data_page(self.platform_name)
                 return
@@ -182,7 +220,7 @@ class FlowBuilder:
             logger.error("Donation failed for %s", self.platform_name)
             yield from ph.emit_log("info", f"[{self.platform_name}] Donation result: failed")
             _ = yield ph.render_donate_failure_page(self.platform_name)
-            return
+            raise TaskIncompleteError("donation_failed")
 
         yield from ph.emit_log("info", f"[{self.platform_name}] Donation result: success")
 

--- a/packages/python/port/main.py
+++ b/packages/python/port/main.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 from port.api.commands import CommandSystemExit, CommandUIRender, CommandSystemDonate
 from port.api.file_utils import AsyncFileAdapter
 from port.helpers import ui_locale
+from port.helpers.flow_builder import TaskIncompleteError
 from port.script import process
 import port.api.props as props
 import port.helpers.port_helpers as ph
@@ -79,11 +80,26 @@ def error_flow(platform: str | None, tb: str):
     yield ph.render_task_incomplete_page(platform or "error")
 
 
+def incomplete_flow(platform: str | None):
+    """Terminal handler for TaskIncompleteError: a flow that ended without
+    completion but with nothing to report — no error-report consent step.
+
+    Resolvable pre-exit acknowledgment (ADR-0039); must never become an
+    unresolved end page (the ADR-0025 EndPage hang).
+    """
+    yield ph.render_task_incomplete_page(platform or "error")
+
+
 class ScriptWrapper(Generator):
     def __init__(self, script, platform: str | None = None):
         self.script = script
         self.platform = platform or "unknown"
         self._error_handler = None
+        # (code, info) for the terminal exit once a handler flow exhausts.
+        # Defaults are the error-flow pair; TaskIncompleteError overrides
+        # them with its own category (ADR-0039).
+        self._exit_code = 1
+        self._exit_info = "Error flow completed"
 
     def send(self, data):
         if self._error_handler is not None:
@@ -91,11 +107,11 @@ class ScriptWrapper(Generator):
                 command = self._error_handler.send(data)
                 return command.toDict()
             except StopIteration:
-                # Error-end, not flow-end: a nonzero code tells the host the
+                # Handler-end, not flow-end: a nonzero code tells the host the
                 # task was NOT completed (Issue #123). The info string crosses
                 # the bridge unconsented and must stay free of exception text
                 # (ADR-0022/0023).
-                return CommandSystemExit(1, "Error flow completed").toDict()
+                return CommandSystemExit(self._exit_code, self._exit_info).toDict()
 
         # Automatically wrap JS file readers with AsyncFileAdapter
         if data and getattr(data, "__type__", None) == "PayloadFile":
@@ -109,6 +125,16 @@ class ScriptWrapper(Generator):
                 command = self.script.send(None)
         except StopIteration:
             return CommandSystemExit(0, "End of script").toDict()
+        except TaskIncompleteError as e:
+            # The flow declared itself incomplete (abandoned, upload
+            # rejected, donation failed). No error to report — go straight
+            # to the task-incomplete page, then exit with the flow's own
+            # fixed (code, info) pair.
+            self._exit_code = e.exit_code
+            self._exit_info = e.exit_info
+            self._error_handler = incomplete_flow(self.platform)
+            command = next(self._error_handler)
+            return command.toDict()
         except Exception:
             tb = traceback.format_exc()
             self._error_handler = error_flow(self.platform, tb)

--- a/packages/python/tests/test_flow_builder.py
+++ b/packages/python/tests/test_flow_builder.py
@@ -15,7 +15,7 @@ from collections import Counter
 from unittest.mock import MagicMock, patch
 
 import pytest
-from port.helpers.flow_builder import FlowBuilder
+from port.helpers.flow_builder import FlowBuilder, TaskIncompleteError
 from port.helpers.uploads import FileTooLargeError
 from port.api.commands import CommandUIRender, CommandSystemDonate, CommandSystemLog
 from port.api.d3i_props import ExtractionResult
@@ -144,11 +144,31 @@ class TestRetryPath:
         cmd = advance_past_logs(gen, make_payload_file())
         assert isinstance(cmd, CommandUIRender)
 
+    def test_retry_declined_raises_abandoned(self):
+        """Declining the retry prompt must NOT exhaust the generator (exit 0 /
+        completed at the host) — it raises TaskIncompleteError with the
+        participant-abandoned exit code so the host keeps the task pending."""
+        flow = StubFlow(validation_status=1)
+        gen = flow.start_flow()
+
+        # File prompt
+        cmd = start_and_skip_logs(gen)
+        assert isinstance(cmd, CommandUIRender)
+
+        # Upload invalid file → milestones → retry prompt
+        cmd = advance_past_logs(gen, make_payload_file())
+        assert isinstance(cmd, CommandUIRender)
+
+        # User clicks "Continue" (declines retry)
+        with pytest.raises(TaskIncompleteError) as exc:
+            advance_past_logs(gen, make_payload("PayloadFalse"))
+        assert exc.value.exit_code == 2
+
 
 class TestSkipPath:
     """User skips file selection (anything other than PayloadFile)."""
 
-    def test_skip_returns_immediately(self):
+    def test_skip_raises_abandoned(self):
         flow = StubFlow()
         gen = flow.start_flow()
 
@@ -157,9 +177,11 @@ class TestSkipPath:
         assert isinstance(cmd, CommandUIRender)
 
         # User skips with non-PayloadFile response — emits an
-        # "Upload skipped" diagnostic log, then returns.
-        with pytest.raises(StopIteration):
+        # "Upload skipped" diagnostic log, then ends abandoned so the
+        # host keeps the task pending instead of completing it.
+        with pytest.raises(TaskIncompleteError) as exc:
             advance_past_logs(gen, make_payload("PayloadFalse"))
+        assert exc.value.exit_code == 2
 
     def test_payload_string_now_treated_as_skip(self):
         """SRC compat dropped per ADR-0026: PayloadString is not a valid upload."""
@@ -170,9 +192,10 @@ class TestSkipPath:
         assert isinstance(cmd, CommandUIRender)
 
         # PayloadString hits the same skip branch as any other non-PayloadFile,
-        # which now emits an "Upload skipped" diagnostic log before returning.
-        with pytest.raises(StopIteration):
+        # which emits an "Upload skipped" diagnostic log and ends abandoned.
+        with pytest.raises(TaskIncompleteError) as exc:
             advance_past_logs(gen, make_payload("PayloadString", value="/tmp/legacy.zip"))
+        assert exc.value.exit_code == 2
 
 
 class TestNoDataPath:
@@ -194,6 +217,21 @@ class TestNoDataPath:
         with pytest.raises(StopIteration):
             gen.send(make_payload("PayloadTrue"))
 
+    def test_no_data_with_extraction_errors_is_a_failure_not_a_completion(self):
+        """Zero tables WITH extraction errors is an extraction failure, never
+        the clean no-data acknowledgment (which completes) — see ADR-0019's
+        no-data/extraction-bug separation. It routes through the uncaught-error
+        path, so the participant is offered the error report and stays pending."""
+        flow = StubFlow(tables=[])
+        flow.extract_data = lambda file, validation: ExtractionResult(
+            tables=[], errors=Counter({"KeyError": 3})
+        )
+        gen = flow.start_flow()
+
+        start_and_skip_logs(gen)
+        with pytest.raises(RuntimeError):
+            advance_past_logs(gen, make_payload_file())
+
 
 class TestSafetyErrorPath:
     """File fails safety check (oversize / chunked-export sentinel)."""
@@ -202,7 +240,7 @@ class TestSafetyErrorPath:
         "port.helpers.flow_builder.uploads.check_payload_size",
         side_effect=FileTooLargeError("too big"),
     )
-    def test_safety_error_shows_page_then_returns(self, mock_check):
+    def test_safety_error_shows_page_then_raises_upload_rejected(self, mock_check):
         flow = StubFlow()
         gen = flow.start_flow()
 
@@ -214,16 +252,17 @@ class TestSafetyErrorPath:
         cmd = advance_past_logs(gen, make_payload_file(size=3 * 1024**3))
         assert isinstance(cmd, CommandUIRender)
 
-        # User acknowledges
-        with pytest.raises(StopIteration):
+        # User acknowledges → upload-rejected exit, not a completion
+        with pytest.raises(TaskIncompleteError) as exc:
             gen.send(make_payload("PayloadTrue"))
+        assert exc.value.exit_code == 4
 
 
 class TestDonateFailurePath:
     """Donation fails after consent."""
 
     @patch("port.helpers.flow_builder.ph.handle_donate_result", return_value=False)
-    def test_donate_failure_shows_page_then_returns(self, mock_handle):
+    def test_donate_failure_shows_page_then_raises_donation_failed(self, mock_handle):
         flow = StubFlow()
         gen = flow.start_flow()
 
@@ -242,9 +281,29 @@ class TestDonateFailurePath:
         cmd = advance_past_logs(gen, make_payload("PayloadResponse", success=False))
         assert isinstance(cmd, CommandUIRender)
 
-        # User acknowledges
-        with pytest.raises(StopIteration):
+        # User acknowledges → donation-failed exit, not a completion
+        with pytest.raises(TaskIncompleteError) as exc:
             gen.send(make_payload("PayloadTrue"))
+        assert exc.value.exit_code == 3
+
+    @patch("port.helpers.flow_builder.ph.handle_donate_result", return_value=False)
+    def test_decline_record_failure_stays_silent_completion(self, mock_handle):
+        """A failed decline-record delivery is invisible infrastructure: the
+        participant declined to donate, so the flow still completes (exit 0)."""
+        flow = StubFlow()
+        gen = flow.start_flow()
+
+        start_and_skip_logs(gen)
+        cmd = advance_past_logs(gen, make_payload_file())
+        assert isinstance(cmd, CommandUIRender)
+
+        # User declines consent → decline record donated
+        cmd = advance_past_logs(gen, make_payload("PayloadFalse"))
+        assert isinstance(cmd, CommandSystemDonate)
+
+        # Delivery of the decline record fails → silent, plain exhaustion
+        with pytest.raises(StopIteration):
+            advance_past_logs(gen, make_payload("PayloadResponse", success=False))
 
 
 class TestSessionIdType:

--- a/packages/python/tests/test_main_queue.py
+++ b/packages/python/tests/test_main_queue.py
@@ -152,6 +152,60 @@ def test_error_exit_info_contains_no_exception_text():
     assert "Traceback" not in exit_command["info"]
 
 
+def test_task_incomplete_renders_page_then_exits_with_flow_code():
+    """A TaskIncompleteError from the flow skips the error-report consent page:
+    the participant lands directly on the task-incomplete page, and the exit
+    carries the exception's own code/info instead of the error-flow defaults."""
+    import json
+
+    from port.helpers.flow_builder import TaskIncompleteError
+
+    def abandoning():
+        _ = yield
+        raise TaskIncompleteError("abandoned")
+
+    wrapper = ScriptWrapper(abandoning(), platform="X")
+
+    incomplete_page = wrapper.send(None)
+    assert incomplete_page["__type__"] == "CommandUIRender"
+    assert incomplete_page["page"]["__type__"] == "PropsUIPageDataSubmission"
+    assert "could not be completed" in json.dumps(incomplete_page)
+
+    exit_command = wrapper.send(_Payload("PayloadTrue"))
+    assert exit_command["__type__"] == "CommandSystemExit"
+    assert exit_command["code"] == 2
+    assert exit_command["info"] == "Participant abandoned the task"
+
+
+def test_task_incomplete_exit_uses_each_reasons_own_literal():
+    """Every TaskIncompleteError reason crosses the bridge with its own fixed
+    PII-free (code, info) pair from the EXITS table — nothing from the raise
+    site leaks, and no reason maps to the success exit."""
+    from port.helpers.flow_builder import TaskIncompleteError
+
+    for reason, (code, info) in TaskIncompleteError.EXITS.items():
+        def incomplete():
+            _ = yield
+            raise TaskIncompleteError(reason)
+
+        wrapper = ScriptWrapper(incomplete(), platform="X")
+        wrapper.send(None)  # task-incomplete page
+        exit_command = wrapper.send(_Payload("PayloadTrue"))
+        assert exit_command["__type__"] == "CommandSystemExit"
+        assert exit_command["code"] == code
+        assert exit_command["code"] != 0
+        assert exit_command["info"] == info
+
+
+def test_task_incomplete_rejects_unknown_reason():
+    """Raise sites cannot invent (code, info) pairs — an unknown reason fails
+    at the raise site instead of carrying arbitrary text across the bridge."""
+    from port.helpers.flow_builder import TaskIncompleteError
+
+    with pytest.raises(KeyError):
+        TaskIncompleteError("bogus reason with participant data")
+
+
 def test_start_function_creates_wrapper(monkeypatch):
     """start() returns a ScriptWrapper."""
     def fake_process(session_id, platform):

--- a/tests/error-flow.spec.ts
+++ b/tests/error-flow.spec.ts
@@ -52,3 +52,41 @@ test('error flow donates report, shows task-incomplete page, and exits nonzero',
     .toContain('received exit: 1=Error flow completed');
   expect(consoleMessages.find((m) => m.includes('received exit: 0='))).toBeUndefined();
 });
+
+/**
+ * A participant who uploads an invalid file and then declines the retry
+ * prompt has NOT completed the task. The flow ends on the task-incomplete
+ * page with the participant-abandoned exit (code 2), never the success
+ * exit — so the host keeps the task pending and they can try again later.
+ */
+test('declining retry after an invalid file shows task-incomplete page and exits abandoned', async ({ page }) => {
+  const consoleMessages: string[] = [];
+  page.on('console', (msg) => consoleMessages.push(msg.text()));
+
+  await page.goto('http://localhost:3000/');
+  await expect(page.getByRole('heading', { name: 'Select your example file' })).toBeVisible({ timeout: 90000 });
+
+  // Upload a file that is not a zip → validation fails → retry prompt
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByText('Choose file').click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(path.join(__dirname, 'invalid.zip'));
+  await page.getByText('Continue').click();
+
+  await expect(page.getByRole('heading', { name: 'Try again' })).toBeVisible({ timeout: 60000 });
+
+  // Decline the retry ("Continue" is the cancel button; exact match keeps
+  // the prompt body text — which also contains the word — out of scope)
+  await page.getByText('Continue', { exact: true }).click();
+
+  // Terminal task-incomplete page, not a silent completion
+  await expect(page.getByText('Task not completed')).toBeVisible();
+  await expect(page.getByText('This task could not be completed', { exact: false })).toBeVisible();
+  await page.getByText('OK', { exact: true }).click();
+
+  // Participant-abandoned exit; the success exit must never fire
+  await expect
+    .poll(() => consoleMessages.find((m) => m.includes('[FakeBridge] received exit')), { timeout: 30000 })
+    .toContain('received exit: 2=Participant abandoned the task');
+  expect(consoleMessages.find((m) => m.includes('received exit: 0='))).toBeUndefined();
+});

--- a/tests/invalid.zip
+++ b/tests/invalid.zip
@@ -1,0 +1,1 @@
+This is not a zip archive. Deliberately invalid fixture for the retry-declined e2e test.


### PR DESCRIPTION
...are now nonzero

We should agree with Eyra on exit codes soon, but here's where it stands now:

Skip at file picker -- 2
Donation failed -- 3
Upload rejected (i.e. fails validation) -- 4

ScriptWrapper shows the task-incomplete page and exits with the reason's fixed pair. Zero tables with extraction errors now routes through the error flow per ADR-0019 instead of completing as "no data found". Amends ADR-0039 with the  taxonomy and its first grep checks.