### PR TITLE
fix(copy): Changed the incomplete flow pages to more accurately describe buttons and abandoning the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,15 @@ Earlier releases used sequential numbering (#1-#5) matching the upstream
 
 ### Changed
 
+* **Incomplete-flow copy tells the truth about what the buttons do.** The
+  retry prompt's cancel button is now "Stop for now" instead of "Continue"
+  (declining ends the attempt as participant-abandoned and the task stays
+  pending — the old copy implied the file would be accepted), and its text
+  says so plainly. The "Task not completed" page now points participants
+  at the host's Close button to return to their task list, instead of
+  telling them to refresh — verified on live Next that after a nonzero
+  exit the host paints nothing, so Close is the only visible way back.
+  All five locales updated in their established registers.
 * Pyright debt cleanup: upload consumers are typed as
   `SeekableBinaryReader` (ADR-0026), TikTok extractor payloads are
   narrowed before use, and the remaining optional/union type errors

--- a/packages/python/port/helpers/port_helpers.py
+++ b/packages/python/port/helpers/port_helpers.py
@@ -46,13 +46,16 @@ def render_page(
 
 def generate_retry_prompt(platform_name: str) -> props.PropsUIPromptConfirm:
     """
-    Generate a bilingual retry prompt for file processing errors.
+    Generate a multi-locale retry prompt for file processing errors.
 
     Returns a PropsUIPromptConfirm with "Try again" (ok → PayloadTrue) and
-    "Continue" (cancel → PayloadFalse) buttons. Using standard feldspar
-    PropsUIPromptConfirm instead of d3i PropsUIPromptRetry which only
-    renders a single button. See ADR-0016 for the broader
-    decision on custom vs standard prompt components.
+    "Stop for now" (cancel → PayloadFalse) buttons. Declining ends the
+    attempt as participant-abandoned (nonzero exit, task stays pending at
+    the host — see ADR-0039), so the copy must never suggest the file will
+    be accepted. Using standard feldspar PropsUIPromptConfirm instead of
+    d3i PropsUIPromptRetry which only renders a single button. See
+    ADR-0016 for the broader decision on custom vs standard prompt
+    components.
 
     Args:
         platform_name: The name of the platform whose file could not be processed.
@@ -60,18 +63,18 @@ def generate_retry_prompt(platform_name: str) -> props.PropsUIPromptConfirm:
 
     text = props.Translatable(
         {
-            "en": f"Unfortunately, we cannot process your {platform_name} file. Continue, if you are sure that you selected the right file. Try again to select a different file.",
-            "nl": f"Helaas, kunnen we uw {platform_name} bestand niet verwerken. Weet u zeker dat u het juiste bestand heeft gekozen? Ga dan verder. Probeer opnieuw als u een ander bestand wilt kiezen.",
-            "de": f"Leider können wir Ihre {platform_name}-Datei nicht verarbeiten. Fahren Sie fort, wenn Sie sicher sind, dass Sie die richtige Datei ausgewählt haben. Versuchen Sie es erneut, um eine andere Datei auszuwählen.",
-            "it": f"Purtroppo non possiamo elaborare il suo file di {platform_name}. Continui se è sicuro di aver selezionato il file giusto. Riprovi per selezionare un file diverso.",
-            "es": f"Lamentablemente, no podemos procesar su archivo de {platform_name}. Continúe si está seguro de que ha seleccionado el archivo correcto. Intente de nuevo para seleccionar un archivo diferente.",
+            "en": f"Unfortunately, we cannot process your {platform_name} file. It does not appear to be the file we expected. Try again to select a different file, or stop for now — you can return to this task later.",
+            "nl": f"Helaas kunnen we uw {platform_name}-bestand niet verwerken. Het lijkt niet het bestand te zijn dat we verwachtten. Probeer opnieuw om een ander bestand te kiezen, of stop voorlopig — u kunt later naar deze taak terugkeren.",
+            "de": f"Leider können wir Ihre {platform_name}-Datei nicht verarbeiten. Es scheint nicht die erwartete Datei zu sein. Versuchen Sie es erneut, um eine andere Datei auszuwählen, oder beenden Sie vorerst — Sie können später zu dieser Aufgabe zurückkehren.",
+            "it": f"Purtroppo non possiamo elaborare il suo file di {platform_name}. Non sembra essere il file previsto. Riprovi per selezionare un file diverso, oppure interrompa per ora — potrà tornare a questa attività più tardi.",
+            "es": f"Lamentablemente, no podemos procesar su archivo de {platform_name}. No parece ser el archivo esperado. Intente de nuevo para seleccionar un archivo diferente, o deténgase por ahora — podrá volver a esta tarea más tarde.",
         }
     )
     ok = props.Translatable(
         {"en": "Try again", "nl": "Probeer opnieuw", "de": "Erneut versuchen", "it": "Riprova", "es": "Intentar de nuevo"}
     )
     cancel = props.Translatable(
-        {"en": "Continue", "nl": "Doorgaan", "de": "Weiter", "it": "Continua", "es": "Continuar"}
+        {"en": "Stop for now", "nl": "Voorlopig stoppen", "de": "Vorerst beenden", "it": "Interrompi per ora", "es": "Detener por ahora"}
     )
     return props.PropsUIPromptConfirm(text, ok, cancel)
 
@@ -394,13 +397,17 @@ def render_safety_error_page(platform_name: str, error: Exception) -> CommandUIR
 
 
 def render_task_incomplete_page(platform_name: str) -> CommandUIRender:
-    """Render the terminal page of the error flow: the task was not completed
-    and the participant can retry by refreshing the page.
+    """Render the terminal page of an incomplete flow: the task was not
+    completed and the participant returns to the task list via the host's
+    Close control (the task stays pending, so it can be retried from there).
 
-    Shown after the consent-gated error report (or its skip) so the
-    participant does not land on a stale error page when the flow exits
-    nonzero (Issue #123). Caller should yield and await response before
-    returning.
+    The copy names the host's Close button because after the nonzero exit
+    the host paints nothing itself (verified on live Next 2026-08-27) —
+    Close is the participant's only visible way back. Shown after the
+    consent-gated error report (or its skip) and on TaskIncompleteError
+    endings, so the participant does not land on a stale page when the
+    flow exits nonzero (Issue #123). Caller should yield and await
+    response before returning.
     """
     header = props.PropsUIHeader(
         props.Translatable({
@@ -413,11 +420,11 @@ def render_task_incomplete_page(platform_name: str) -> CommandUIRender:
     )
     body = props.PropsUIPromptConfirm(
         text=props.Translatable({
-            "en": "This task could not be completed. You can try again by refreshing this page. If the problem persists, please contact the researcher.",
-            "nl": "Deze taak kon niet worden voltooid. U kunt het opnieuw proberen door deze pagina te vernieuwen. Als het probleem aanhoudt, neem dan contact op met de onderzoeker.",
-            "de": "Diese Aufgabe konnte nicht abgeschlossen werden. Sie können es erneut versuchen, indem Sie diese Seite aktualisieren. Wenn das Problem weiterhin besteht, wenden Sie sich bitte an den Forscher.",
-            "it": "Non è stato possibile completare questa attività. Può riprovare aggiornando questa pagina. Se il problema persiste, contatti il ricercatore.",
-            "es": "Esta tarea no se pudo completar. Puede intentarlo de nuevo actualizando esta página. Si el problema persiste, póngase en contacto con el investigador.",
+            "en": "This task could not be completed. Use the Close button to return to your tasks — from there you can try this task again. If the problem persists, please contact the researcher.",
+            "nl": "Deze taak kon niet worden voltooid. Gebruik de knop Sluiten om terug te keren naar uw taken — daar kunt u deze taak opnieuw proberen. Als het probleem aanhoudt, neem dan contact op met de onderzoeker.",
+            "de": "Diese Aufgabe konnte nicht abgeschlossen werden. Verwenden Sie die Schaltfläche Schließen, um zu Ihren Aufgaben zurückzukehren — dort können Sie diese Aufgabe erneut versuchen. Wenn das Problem weiterhin besteht, wenden Sie sich bitte an den Forscher.",
+            "it": "Non è stato possibile completare questa attività. Usi il pulsante Chiudi per tornare alle sue attività — da lì potrà riprovare questa attività. Se il problema persiste, contatti il ricercatore.",
+            "es": "Esta tarea no se pudo completar. Utilice el botón Cerrar para volver a sus tareas — desde allí podrá intentar esta tarea de nuevo. Si el problema persiste, póngase en contacto con el investigador.",
         }),
         ok=props.Translatable({"en": "OK", "nl": "OK", "de": "OK", "it": "OK", "es": "OK"}),
     )

--- a/packages/python/tests/test_flow_builder.py
+++ b/packages/python/tests/test_flow_builder.py
@@ -159,7 +159,7 @@ class TestRetryPath:
         cmd = advance_past_logs(gen, make_payload_file())
         assert isinstance(cmd, CommandUIRender)
 
-        # User clicks "Continue" (declines retry)
+        # User clicks "Stop for now" (declines retry)
         with pytest.raises(TaskIncompleteError) as exc:
             advance_past_logs(gen, make_payload("PayloadFalse"))
         assert exc.value.exit_code == 2

--- a/packages/python/tests/test_port_helpers.py
+++ b/packages/python/tests/test_port_helpers.py
@@ -59,6 +59,51 @@ class TestRenderTaskIncompletePage:
         confirm = next(p for p in prompts if p["__type__"] == "PropsUIPromptConfirm")
         assert confirm.get("cancel") in (None, {})
 
+    def test_copy_points_at_the_host_close_control(self):
+        """After the nonzero exit the host paints nothing (verified on live
+        Next 2026-08-27): the participant's way back to the task list is the
+        host's own Close control, so the page must name it — not tell them
+        to refresh into the void. The e2e spec pins the opening sentence."""
+        import json
+
+        result = ph.render_task_incomplete_page("TikTok")
+        serialized = json.dumps(result.toDict())
+
+        assert "This task could not be completed" in serialized
+        assert "Close" in serialized
+        assert "refreshing" not in serialized
+
+
+class TestGenerateRetryPrompt:
+    def _confirm(self):
+        return ph.generate_retry_prompt("Facebook").toDict()
+
+    def test_cancel_button_is_not_labelled_continue(self):
+        """'Continue' was a lie: declining the retry ends the attempt and
+        leads to the task-incomplete page. The label must say so."""
+        confirm = self._confirm()
+        assert confirm["cancel"]["translations"]["en"] == "Stop for now"
+        assert all(
+            label != "Continue" for label in confirm["cancel"]["translations"].values()
+        )
+
+    def test_ok_button_stays_try_again(self):
+        confirm = self._confirm()
+        assert confirm["ok"]["translations"]["en"] == "Try again"
+
+    def test_text_no_longer_promises_continuing(self):
+        """The old copy told a participant who was sure about their file to
+        'Continue' — but the file is never processed either way."""
+        confirm = self._confirm()
+        en = confirm["text"]["translations"]["en"]
+        assert "Continue, if you are sure" not in en
+        assert "stop for now" in en
+
+    def test_all_five_locales_present_on_text_and_buttons(self):
+        confirm = self._confirm()
+        for part in ("text", "ok", "cancel"):
+            assert set(confirm[part]["translations"].keys()) == {"en", "nl", "de", "it", "es"}
+
 
 class TestHandleDonateResult:
     def test_success_response(self):

--- a/tests/error-flow.spec.ts
+++ b/tests/error-flow.spec.ts
@@ -75,9 +75,10 @@ test('declining retry after an invalid file shows task-incomplete page and exits
 
   await expect(page.getByRole('heading', { name: 'Try again' })).toBeVisible({ timeout: 60000 });
 
-  // Decline the retry ("Continue" is the cancel button; exact match keeps
-  // the prompt body text — which also contains the word — out of scope)
-  await page.getByText('Continue', { exact: true }).click();
+  // Decline the retry ("Stop for now" is the cancel button; exact match
+  // keeps the prompt body text — which contains the same words in
+  // lowercase — out of scope)
+  await page.getByText('Stop for now', { exact: true }).click();
 
   // Terminal task-incomplete page, not a silent completion
   await expect(page.getByText('Task not completed')).toBeVisible();


### PR DESCRIPTION
## What changed?

The retry prompt: now says "It does not appear to be the file we expected. Try again to select a different file, or stop for now. You can return to this task later." Changed the button to "Stop for now". It's also got translations in the five locales.

The task-incomplete page: "Use the close button to return to your tasks -- from there you can try this task again" 